### PR TITLE
Release v1.5.4: Critical MCP server JSR execution fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/mcp.ts
+++ b/mcp.ts
@@ -111,4 +111,11 @@
  * await mcpServer();
  * ```
  */
+import main from "./src/mcp/index.ts";
+
 export { default } from "./src/mcp/index.ts";
+
+// Auto-start MCP server when run as main module
+if (import.meta.main) {
+  await main();
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.5.3";
+export const CLIMPT_VERSION = "1.5.4";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
Critical release v1.5.4 to fix MCP server execution via JSR package.

## Problem
MCP server was not starting when executed via `jsr:@aidevtool/climpt/mcp` causing Claude Code integration failures.

## Solution
- Fixed `mcp.ts` to auto-execute main function when `import.meta.main` is true
- Version bumped to 1.5.4 to trigger JSR package update

## Changes
- **Critical Fix**: Auto-start MCP server when mcp.ts is run as main module
- **Version**: Bumped to 1.5.4 in src/version.ts and deno.json
- **Compatibility**: Maintains backward compatibility for programmatic imports

This release is essential for Claude Code MCP integration to work properly.

🤖 Generated with [Claude Code](https://claude.ai/code)