### PR TITLE
chore: release version 1.5.6

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.5.5";
+export const CLIMPT_VERSION = "1.5.6";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
Update version to 1.5.6

- Updated version in deno.json from 1.5.5 to 1.5.6
- Updated CLIMPT_VERSION constant in src/version.ts to 1.5.6
- Synchronized version across all configuration files

This release includes the documentation updates from the previous merge.