### PR TITLE
feat: update publish workflow for PR-based deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,9 @@ name: Publish
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,14 @@
 name: Publish
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   publish:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Update publish workflow to trigger on PR merge to main branch

## Changes
- Change trigger from `push` to `pull_request` with `closed` type
- Add condition to only run when PR is actually merged (not just closed)
- Remove `workflow_dispatch` trigger as manual execution is not needed
- Ensure workflow only runs for PRs targeting main branch

## Why
Main branch is protected and only accepts changes via PR merge, so the workflow needs to trigger on PR merge events rather than direct pushes.