### PR TITLE
Release: Update publish workflow for PR-based deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,14 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
+    types: [closed]
+    branches:
+      - main
 
 jobs:
   publish:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Release Summary
Update publish workflow to properly work with protected main branch that only accepts PR merges.

## Key Changes
- **Publish Workflow Update**: Changed trigger from push events to PR merge events
- **Protection Compliance**: Now works with branch protection rules that prevent direct pushes
- **Conditional Execution**: Only runs when PRs are actually merged (not just closed)

## Technical Details
- Trigger: `pull_request` with `types: [closed]` and `branches: [main]`
- Condition: `if: github.event.pull_request.merged == true`
- Action: Runs `deno publish` to deploy to JSR

## Testing
This PR merge will test the new workflow functionality - the publish action should trigger automatically when this PR is merged to main.

Ready for merge and deployment! 🚀