### PR TITLE
feat: Add proper version display for Climpt CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@
  */
 
 // Import the breakdown package dynamically using the version from version.ts
-import { BREAKDOWN_VERSION } from "./version.ts";
+import { CLIMPT_VERSION, BREAKDOWN_VERSION } from "./version.ts";
 
 let runBreakdown: (args: string[]) => Promise<void>;
 
@@ -48,6 +48,8 @@ async function importBreakdown(): Promise<void> {
  * - `to <type> <layer>` - Convert input Markdown to next layer format
  * - `summary <type>` - Generate new Markdown or specified layer Markdown
  * - `defect <type>` - Generate fixes from error logs or defect information
+ * - `--version` or `-v` - Show Climpt and Breakdown version information
+ * - `--help` - Show help message
  * - `version` - Show version information
  * - `help` - Show help message
  *
@@ -125,6 +127,13 @@ async function importBreakdown(): Promise<void> {
  */
 export async function main(_args: string[] = []): Promise<void> {
   try {
+    // Handle version argument
+    if (_args.includes('-v') || _args.includes('--version')) {
+      console.log(`Climpt v${CLIMPT_VERSION}`);
+      console.log(`└── Breakdown v${BREAKDOWN_VERSION}`);
+      return;
+    }
+
     if (!runBreakdown) {
       await importBreakdown();
     }


### PR DESCRIPTION
## 🎯 Problem
`climpt -v` was showing Breakdown version instead of Climpt version, causing confusion about which package version is being used.

## ✅ Solution
- Added proper handling for `-v` and `--version` arguments
- Display both Climpt and Breakdown versions in hierarchical format:
  

## 🧪 Testing
- ✅ Tested locally: `deno run -A cli.ts -v` works correctly  
- ✅ Shows proper version hierarchy
- ✅ CLI documentation updated

## 📝 Changes
- Updated `src/cli.ts` to handle version arguments before delegating to breakdown
- Added `CLIMPT_VERSION` import and usage
- Enhanced CLI documentation with version command info

Ready for merge! 🚀