### PR TITLE
fix: use bare specifiers for MCP SDK imports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -43,6 +43,11 @@
     "build": "deno compile --allow-read --allow-write --allow-net --allow-env --output ./dist/climpt cli.ts",
     "ci": "deno run --allow-read --allow-write --allow-net --allow-env --allow-run jsr:@aidevtool/ci"
   },
+  "imports": {
+    "@modelcontextprotocol/sdk/server": "npm:@modelcontextprotocol/sdk@0.7.0/server/index.js",
+    "@modelcontextprotocol/sdk/server/stdio": "npm:@modelcontextprotocol/sdk@0.7.0/server/stdio.js",
+    "@modelcontextprotocol/sdk/types": "npm:@modelcontextprotocol/sdk@0.7.0/types.js"
+  },
   "compilerOptions": {
     "lib": ["deno.ns", "dom", "es2022"],
     "strict": true

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -11,8 +11,8 @@
  * @module mcp/index
  */
 
-import { Server } from "npm:@modelcontextprotocol/sdk@0.7.0/server/index.js";
-import { StdioServerTransport } from "npm:@modelcontextprotocol/sdk@0.7.0/server/stdio.js";
+import { Server } from "@modelcontextprotocol/sdk/server";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio";
 import {
   type CallToolRequest,
   CallToolRequestSchema,
@@ -22,7 +22,7 @@ import {
   ListPromptsRequestSchema,
   type ListToolsRequest,
   ListToolsRequestSchema,
-} from "npm:@modelcontextprotocol/sdk@0.7.0/types.js";
+} from "@modelcontextprotocol/sdk/types";
 import { CLIMPT_VERSION } from "../version.ts";
 
 console.error("🚀 MCP Server starting...");


### PR DESCRIPTION
## Summary
Fix lint errors in MCP SDK imports by using bare specifiers

## Problem
Remote CI failed with `no-import-prefix` lint errors:
- Inline `npm:` imports not allowed
- Must use bare specifiers from imports map

## Changes
- Added MCP SDK to `imports` in deno.json
- Updated src/mcp/index.ts to use bare specifiers
- All 3 lint errors resolved

## Verification
- ✅ Local lint: `deno lint` passes
- ✅ Local type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)