### PR TITLE
chore: bump version to 1.5.7

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.5.6";
+export const CLIMPT_VERSION = "1.5.7";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
Bump version to 1.5.7 for next release

## Changes
- Update version in deno.json: 1.5.6 → 1.5.7
- Update CLIMPT_VERSION in src/version.ts: 1.5.6 → 1.5.7

## Release Notes
This release includes:
- MCP SDK imports fix (bare specifiers)
- Enhanced README documentation
- MCP registry schema improvements
- CLI version display improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)