### PR TITLE
feat: add Climpt-specific help message

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -130,7 +130,8 @@ async function importBreakdown(): Promise<void> {
  * @internal
  */
 function showHelp(): void {
-  console.log(`Climpt v${CLIMPT_VERSION} - AI-Assisted Development Instruction Tool
+  console.log(
+    `Climpt v${CLIMPT_VERSION} - AI-Assisted Development Instruction Tool
 
 A CLI wrapper around the @tettuan/breakdown JSR package for managing prompts
 and AI interactions.
@@ -190,7 +191,8 @@ MCP Server:
 
 Documentation:
   https://github.com/tettuan/climpt
-`);
+`,
+  );
 }
 
 export async function main(_args: string[] = []): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -125,8 +125,82 @@ async function importBreakdown(): Promise<void> {
  * await main(["--help"]);
  * ```
  */
+/**
+ * Display Climpt help message
+ * @internal
+ */
+function showHelp(): void {
+  console.log(`Climpt v${CLIMPT_VERSION} - AI-Assisted Development Instruction Tool
+
+A CLI wrapper around the @tettuan/breakdown JSR package for managing prompts
+and AI interactions.
+
+Usage:
+  climpt [command] [options]
+  climpt-<profile> <directive> <layer> [options]
+
+Basic Commands:
+  init                    Initialize breakdown configuration
+  --help, -h              Show this help message
+  --version, -v           Show Climpt and Breakdown version information
+
+Command Syntax:
+  climpt-<profile> <directive> <layer> [options]
+
+  Components:
+    <profile>    Profile name (e.g., git, breakdown, build)
+    <directive>  Action to execute (e.g., create, analyze, trace)
+    <layer>      Target layer (e.g., refinement-issue, quality-metrics)
+    [options]    Various options
+
+Options:
+  Input/Output:
+    -f, --from=<file>           Specify input file
+    -o, --destination=<path>    Specify output destination
+    (STDIN)                     Receive data from standard input
+
+  Processing Mode:
+    -i, --input=<layer>         Specify input layer type (default: "default")
+    -a, --adaptation=<type>     Specify prompt type/variation
+
+  Custom Variables:
+    --uv-<name>=<value>         Define user variables (e.g., --uv-max-line-num=100)
+
+  System:
+    --config=<prefix>           Use custom config prefix
+    --help, -h                  Show this help message
+    --version, -v               Show version information
+
+Examples:
+  # Initialize configuration
+  climpt init
+
+  # Create refinement issue from requirements
+  climpt-git create refinement-issue -f=requirements.md -o=./issues/
+
+  # Break down issue to tasks
+  climpt-breakdown to task -i=issue -f=issue.md -a=detailed --uv-storypoint=5
+
+  # Generate from standard input
+  echo "error log" | climpt-diagnose trace stack -i=test -o=./output
+
+MCP Server:
+  Climpt supports Model Context Protocol (MCP) for AI assistant integration.
+  For details: https://jsr.io/@aidevtool/climpt
+
+Documentation:
+  https://github.com/tettuan/climpt
+`);
+}
+
 export async function main(_args: string[] = []): Promise<void> {
   try {
+    // Handle help argument
+    if (_args.includes("-h") || _args.includes("--help")) {
+      showHelp();
+      return;
+    }
+
     // Handle version argument
     if (_args.includes("-v") || _args.includes("--version")) {
       console.log(`Climpt v${CLIMPT_VERSION}`);


### PR DESCRIPTION
## Summary
Add Climpt-specific help message for `--help`/`-h` flags

## Problem
- Previously, `-h`/`--help` was passed through to breakdown
- Users saw breakdown's help instead of Climpt's help
- No information about Climpt's wrapper functionality or MCP support

## Changes
- Intercept `--help`/`-h` before delegating to breakdown
- Display comprehensive Climpt usage information including:
  - Command syntax (`climpt-<profile> <directive> <layer>`)
  - Options reference (input/output, processing mode, custom variables)
  - Practical examples
  - MCP server mention with JSR URL
- Keep `--version`/`-v` showing both Climpt and Breakdown versions

## Testing
```bash
$ deno run -A cli.ts --help
Climpt v1.5.7 - AI-Assisted Development Instruction Tool
...

$ deno run -A cli.ts -h
# Same output

$ deno run -A cli.ts -v
Climpt v1.5.7
└── Breakdown v1.4.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)