### PR TITLE
Release v1.5.7

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -125,8 +125,84 @@ async function importBreakdown(): Promise<void> {
  * await main(["--help"]);
  * ```
  */
+/**
+ * Display Climpt help message
+ * @internal
+ */
+function showHelp(): void {
+  console.log(
+    `Climpt v${CLIMPT_VERSION} - AI-Assisted Development Instruction Tool
+
+A CLI wrapper around the @tettuan/breakdown JSR package for managing prompts
+and AI interactions.
+
+Usage:
+  climpt [command] [options]
+  climpt-<profile> <directive> <layer> [options]
+
+Basic Commands:
+  init                    Initialize breakdown configuration
+  --help, -h              Show this help message
+  --version, -v           Show Climpt and Breakdown version information
+
+Command Syntax:
+  climpt-<profile> <directive> <layer> [options]
+
+  Components:
+    <profile>    Profile name (e.g., git, breakdown, build)
+    <directive>  Action to execute (e.g., create, analyze, trace)
+    <layer>      Target layer (e.g., refinement-issue, quality-metrics)
+    [options]    Various options
+
+Options:
+  Input/Output:
+    -f, --from=<file>           Specify input file
+    -o, --destination=<path>    Specify output destination
+    (STDIN)                     Receive data from standard input
+
+  Processing Mode:
+    -i, --input=<layer>         Specify input layer type (default: "default")
+    -a, --adaptation=<type>     Specify prompt type/variation
+
+  Custom Variables:
+    --uv-<name>=<value>         Define user variables (e.g., --uv-max-line-num=100)
+
+  System:
+    --config=<prefix>           Use custom config prefix
+    --help, -h                  Show this help message
+    --version, -v               Show version information
+
+Examples:
+  # Initialize configuration
+  climpt init
+
+  # Create refinement issue from requirements
+  climpt-git create refinement-issue -f=requirements.md -o=./issues/
+
+  # Break down issue to tasks
+  climpt-breakdown to task -i=issue -f=issue.md -a=detailed --uv-storypoint=5
+
+  # Generate from standard input
+  echo "error log" | climpt-diagnose trace stack -i=test -o=./output
+
+MCP Server:
+  Climpt supports Model Context Protocol (MCP) for AI assistant integration.
+  For details: https://jsr.io/@aidevtool/climpt
+
+Documentation:
+  https://github.com/tettuan/climpt
+`,
+  );
+}
+
 export async function main(_args: string[] = []): Promise<void> {
   try {
+    // Handle help argument
+    if (_args.includes("-h") || _args.includes("--help")) {
+      showHelp();
+      return;
+    }
+
     // Handle version argument
     if (_args.includes("-v") || _args.includes("--version")) {
       console.log(`Climpt v${CLIMPT_VERSION}`);

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.5.6";
+export const CLIMPT_VERSION = "1.5.7";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
Release Climpt v1.5.7 with help improvements, MCP fixes, and documentation updates

## Changes
- **feat**: Add Climpt-specific help message for `--help`/`-h` (#31)
- **chore**: Bump version to 1.5.7 (#30)
- **fix**: Use bare specifiers for MCP SDK imports (#28)
- **docs**: Enhance README with comprehensive usage documentation (#26)
- **feat**: Add proper version display for Climpt CLI (#25)

## Version
- Climpt: 1.5.6 → 1.5.7
- Breakdown: 1.4.1 (unchanged)

## Key Features
### Help Message
- Intercept `--help`/`-h` to show Climpt-specific help
- Comprehensive usage information with examples
- MCP server support mention

### MCP SDK
- Fixed lint errors by using bare specifiers
- Added imports map in deno.json

### Documentation
- Enhanced README with detailed options reference
- Added template variables mapping
- Improved usage examples

## Conflict Resolution
- Resolved merge conflict in src/cli.ts
- Both help handler and version handler now present

## Related PRs
- #31 feat: add Climpt-specific help message
- #30 chore: bump version to 1.5.7
- #28 fix: use bare specifiers for MCP SDK imports
- #26 docs: enhance README and fix MCP schema
- #25 fix: climpt version display

🤖 Generated with [Claude Code](https://claude.com/claude-code)