### PR TITLE
fix: update CLIMPT_VERSION to 1.5.9

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.5.7";
+export const CLIMPT_VERSION = "1.5.9";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Fix CLIMPT_VERSION in src/version.ts to match deno.json (1.5.9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)