### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2025-01-22
+
+### Added
+- C3L (Claude Code CLI) specification v0.5 documentation
+- Enhanced MCP execute tool to follow C3L v0.5 specification
+
+### Changed
+- Improved execute tool documentation with clearer option format requirements
+- Simplified execute tool options description for better usability
+
+### Removed
+- STDIN support from MCP execute tool (breaking change - follows C3L v0.5 specification)
+
 ## [1.5.1] - 2025-01-17
 
 ### Fixed

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.5.10",
+  "version": "1.6.0",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.5.10";
+export const CLIMPT_VERSION = "1.6.0";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Bump version to 1.6.0 (minor version)
- Add CHANGELOG for v1.6.0 release
  - MCP execute tool updated to follow C3L v0.5 specification
  - Breaking change: Removed STDIN support from MCP execute tool
  - Enhanced documentation for execute tool

## Changes
- **Added**: C3L v0.5 specification documentation
- **Added**: Enhanced MCP execute tool following C3L v0.5
- **Changed**: Improved execute tool documentation
- **Removed**: STDIN support from MCP execute tool (breaking change)

## Test plan
- [x] All CI checks passed
- [x] Version updated in deno.json and src/version.ts
- [x] CHANGELOG updated with new release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)