### PR TITLE
docs: improve JSR documentation coverage to 100%

### DIFF
--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -7,16 +7,61 @@
  * Command definition loaded from registry.json
  */
 export interface Command {
+  /**
+   * Domain identifier (first level of C3L hierarchy)
+   * @example "git", "spec", "test", "code", "docs", "meta"
+   */
   c1: string;
+
+  /**
+   * Action identifier (second level of C3L hierarchy)
+   * @example "create", "analyze", "execute", "generate"
+   */
   c2: string;
+
+  /**
+   * Target identifier (third level of C3L hierarchy)
+   * @example "unstaged-changes", "quality-metrics", "unit-tests"
+   */
   c3: string;
+
+  /**
+   * Human-readable description of what this command does
+   */
   description: string;
+
+  /**
+   * Optional usage instructions or examples for the command
+   */
   usage?: string;
+
+  /**
+   * Optional command options configuration
+   */
   options?: {
+    /**
+     * Input parameter names that can be provided to the command
+     */
     input?: string[];
+
+    /**
+     * Adaptation parameter names for command customization
+     */
     adaptation?: string[];
+
+    /**
+     * Whether this command supports file input via -f/--file flag
+     */
     file?: boolean;
+
+    /**
+     * Whether this command supports stdin input
+     */
     stdin?: boolean;
+
+    /**
+     * Whether this command supports destination output via -d/--destination flag
+     */
     destination?: boolean;
   };
 }
@@ -25,10 +70,30 @@ export interface Command {
  * Search result with similarity score
  */
 export interface SearchResult {
+  /**
+   * Domain identifier from the matched command
+   */
   c1: string;
+
+  /**
+   * Action identifier from the matched command
+   */
   c2: string;
+
+  /**
+   * Target identifier from the matched command
+   */
   c3: string;
+
+  /**
+   * Description of the matched command
+   */
   description: string;
+
+  /**
+   * Cosine similarity score (0-1) indicating relevance to search query
+   * Higher scores indicate better matches
+   */
   score: number;
 }
 
@@ -36,10 +101,28 @@ export interface SearchResult {
  * Registry structure
  */
 export interface Registry {
+  /**
+   * Version of the registry schema
+   */
   version: string;
+
+  /**
+   * Human-readable description of this registry
+   */
   description: string;
+
+  /**
+   * Tools configuration and command definitions
+   */
   tools: {
+    /**
+     * Optional array of available tool configuration names
+     */
     availableConfigs?: string[];
+
+    /**
+     * Array of command definitions available in this registry
+     */
     commands: Command[];
   };
 }
@@ -49,7 +132,14 @@ export interface Registry {
  * Maps agent names to their registry.json paths
  */
 export interface MCPConfig {
+  /**
+   * Mapping of agent names to their respective registry.json file paths
+   * @example { "climpt": ".agent/climpt/registry.json", "inspector": ".agent/inspector/registry.json" }
+   */
   registries: {
+    /**
+     * Path to the registry.json file for this agent
+     */
     [agentName: string]: string;
   };
 }


### PR DESCRIPTION
## Release v1.7.1 - Documentation Enhancement

### 🎯 Primary Change
Complete JSDoc documentation for all interface properties to achieve 100% JSR documentation coverage.

### 📚 Documentation Improvements
Added comprehensive JSDoc to `src/mcp/types.ts`:

**Command Interface** (11 properties)
- C3L hierarchy identifiers (c1, c2, c3) with examples
- Usage instructions and options with detailed explanations

**SearchResult Interface** (5 properties)
- Match identifiers and descriptions
- Similarity scoring context

**Registry Interface** (5 properties)
- Schema version and tools configuration
- Nested properties fully documented

**MCPConfig Interface** (2 properties)
- Agent registry mapping with examples

### 📈 Impact
- JSR Documentation Score: **50% → 100%**
- All exported symbols and properties documented
- Meets "Complete docs" requirement for JSR

### ✅ Quality Assurance
All CI checks passed:
- Type Check: 21 files ✓
- JSR Compatibility: Success ✓
- Tests: 16 passed ✓
- Lint & Format: Clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)