### PR TITLE
chore: release v1.7.1

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.7.0";
+export const CLIMPT_VERSION = "1.7.1";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Release v1.7.1

### Changes
- Bump version from 1.7.0 to 1.7.1
- Fix version alignment with JSR documentation improvements

### Background
Previous v1.7.1 tag was applied without updating package version in deno.json, causing publish workflow to skip. This PR corrects the version to ensure proper JSR publication.

### Files Changed
- `deno.json`: version 1.7.0 → 1.7.1
- `src/version.ts`: CLIMPT_VERSION 1.7.0 → 1.7.1

### Testing
This follows the standard release workflow:
1. release/v1.7.1 → develop
2. develop → main
3. Tag v1.7.1 on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)