### PR TITLE
Release v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2025-12-07
+
+### Changed
+- Refactored registry generation to use `@aidevtool/frontmatter-to-schema` package
+- Standardized all prompt descriptions to English
+
+### Added
+- `climpt-meta build frontmatter` command for generating C3L v0.5 compliant frontmatter
+- `climpt-meta create instruction` command for creating new instruction files
+- Registry generation script (`scripts/generate-registry.ts`)
+- Frontmatter-to-schema configuration files
+
+### Removed
+- `climpt-code` domain (moved to separate project)
+
 ## [1.8.0] - 2025-11-26
 
 ### Changed

--- a/README.ja.md
+++ b/README.ja.md
@@ -307,13 +307,13 @@ MCPサーバーは各エージェントの`.agent/{agent}/registry.json`から�
   "version": string,           // レジストリバージョン（例: "1.0.0"）
   "description": string,       // レジストリ全体の説明
   "tools": {
-    // ツール名の配列 - 各ツールはclimpt-{name}として利用可能
-    "availableConfigs": string[],  // ["git", "spec", "test", "code", "docs", "meta"]
+    // ツール名の配列 - C3L v0.5形式（climpt-{domain}）
+    "availableConfigs": string[],  // ["climpt-git", "climpt-meta"]
 
     // コマンドレジストリ - 利用可能なすべてのC3Lコマンドを定義
     "commands": [
       {
-        "c1": string,         // ドメイン/カテゴリ（git, spec, test, code, docs, meta）
+        "c1": string,         // ドメイン/カテゴリ - C3L v0.5形式（climpt-git, climpt-meta）
         "c2": string,         // アクション/ディレクティブ（create, analyze, execute など）
         "c3": string,         // ターゲット/レイヤー（refinement-issue, quality-metrics など）
         "description": string,// コマンドの説明
@@ -339,104 +339,65 @@ MCPサーバーは各エージェントの`.agent/{agent}/registry.json`から�
   "description": "Climpt MCPサーバーとコマンドレジストリの包括的設定",
   "tools": {
     "availableConfigs": [
-      "code",
-      "docs",
-      "git",
-      "meta",
-      "spec",
-      "test"
+      "climpt-git",
+      "climpt-meta"
     ],
     "commands": [
-      // Gitコマンド
       {
-        "c1": "git",
-        "c2": "create",
-        "c3": "refinement-issue",
-        "description": "要件ドキュメントからリファインメント課題を作成",
-        "usage": "要件ドキュメントからリファインメント課題を作成します。\n例: climpt-git create refinement-issue -f requirements.md",
+        "c1": "climpt-git",
+        "c2": "decide-branch",
+        "c3": "working-branch",
+        "description": "タスク内容に基づいて新規ブランチを作成するか現在のブランチで続行するかを決定",
+        "usage": "climpt-git decide-branch working-branch",
+        "options": {
+          "edition": ["default"],
+          "adaptation": ["default"],
+          "file": false,
+          "stdin": true,
+          "destination": false
+        }
+      },
+      {
+        "c1": "climpt-git",
+        "c2": "merge-up",
+        "c3": "base-branch",
+        "description": "派生した作業ブランチを親作業ブランチにマージ",
+        "usage": "climpt-git merge-up base-branch",
+        "options": {
+          "edition": ["default"],
+          "adaptation": ["default"],
+          "file": false,
+          "stdin": false,
+          "destination": false
+        }
+      },
+      {
+        "c1": "climpt-meta",
+        "c2": "build",
+        "c3": "frontmatter",
+        "description": "Climpt指示ファイル用のC3L v0.5準拠フロントマターを生成",
+        "usage": "climpt-meta build frontmatter",
         "options": {
           "edition": ["default"],
           "adaptation": ["default", "detailed"],
-          "file": true,
-          "stdin": false,
+          "file": false,
+          "stdin": true,
           "destination": true
         }
       },
       {
-        "c1": "git",
-        "c2": "analyze",
-        "c3": "commit-history",
-        "description": "コミット履歴を分析してインサイトを生成"
-      },
-
-      // Specコマンド
-      {
-        "c1": "spec",
-        "c2": "analyze",
-        "c3": "quality-metrics",
-        "description": "仕様の品質と完全性を分析"
-      },
-      {
-        "c1": "spec",
-        "c2": "validate",
-        "c3": "requirements",
-        "description": "要件を標準に対して検証"
-      },
-
-      // Testコマンド
-      {
-        "c1": "test",
-        "c2": "execute",
-        "c3": "integration-suite",
-        "description": "統合テストスイートを実行"
-      },
-      {
-        "c1": "test",
-        "c2": "generate",
-        "c3": "unit-tests",
-        "description": "仕様からユニットテストを生成"
-      },
-
-      // Codeコマンド
-      {
-        "c1": "code",
+        "c1": "climpt-meta",
         "c2": "create",
-        "c3": "implementation",
-        "description": "設計ドキュメントから実装を作成"
-      },
-      {
-        "c1": "code",
-        "c2": "refactor",
-        "c3": "architecture",
-        "description": "パターンに基づいてコードアーキテクチャをリファクタリング"
-      },
-
-      // Docsコマンド
-      {
-        "c1": "docs",
-        "c2": "generate",
-        "c3": "api-reference",
-        "description": "APIリファレンスドキュメントを生成"
-      },
-      {
-        "c1": "docs",
-        "c2": "update",
-        "c3": "user-guide",
-        "description": "ユーザーガイドドキュメントを更新"
-      },
-
-      // Metaコマンド
-      {
-        "c1": "meta",
-        "c2": "list",
-        "c3": "available-commands",
-        "description": "利用可能なすべてのClimptコマンドをリスト"
-      },
-      {
-        "c1": "meta",
-        "c2": "resolve",
-        "c3": "command-definition",
-        "description": "コマンド定義を解決して表示"
+        "c3": "instruction",
+        "description": "C3L仕様に従って、標準入力から新しいClimpt指示ファイルを作成",
+        "usage": "climpt-meta create instruction",
+        "options": {
+          "edition": ["default"],
+          "adaptation": ["default", "detailed"],
+          "file": false,
+          "stdin": true,
+          "destination": true
+        }
       }
     ]
   }
@@ -452,7 +413,7 @@ MCPサーバーは各エージェントの`.agent/{agent}/registry.json`から�
 **フィールドの説明**:
 - `version`: レジストリスキーマのバージョン
 - `description`: レジストリ全体の説明
-- `availableConfigs`: `climpt-{name}`コマンドとして利用可能になるツール名の配列
+- `availableConfigs`: C3L v0.5形式のツール名の配列（例: `climpt-git`, `climpt-meta`）
 - `commands`: C3L仕様に従ったコマンド定義の配列
   - `c1/c2/c3`: コマンド構造（ドメイン/アクション/ターゲット）
   - `description`: コマンドの目的

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Climpt includes a built-in MCP server that allows AI assistants like Claude to i
 ### MCP Features
 
 - **Dynamic Tool Loading**: Automatically loads available tools from `.agent/climpt/registry.json`
-- **Full Command Registry Access**: All Climpt commands (code, docs, git, meta, spec, test) are available
+- **Full Command Registry Access**: All Climpt commands (git, meta) are available
 - **Multiple Registry Support** (v1.6.1+): Manage and switch between multiple agent registries
 - **Registry Configuration Management**: Configuration-based registry management via `.agent/climpt/mcp/config.json`
 - **Performance Optimization**: Fast responses through registry caching
@@ -307,13 +307,13 @@ The MCP server reads configuration from each agent's `.agent/{agent}/registry.js
   "version": string,           // Registry version (e.g., "1.0.0")
   "description": string,       // Overall registry description
   "tools": {
-    // Array of tool names - each tool is available as climpt-{name}
-    "availableConfigs": string[],  // ["git", "spec", "test", "code", "docs", "meta"]
+    // Array of tool names in C3L v0.5 format (climpt-{domain})
+    "availableConfigs": string[],  // ["climpt-git", "climpt-meta"]
 
     // Command registry - defines all available C3L commands
     "commands": [
       {
-        "c1": string,         // Domain/category (git, spec, test, code, docs, meta)
+        "c1": string,         // Domain/category in C3L v0.5 format (climpt-git, climpt-meta)
         "c2": string,         // Action/directive (create, analyze, execute, etc.)
         "c3": string,         // Target/layer (refinement-issue, quality-metrics, etc.)
         "description": string,// Command description
@@ -336,107 +336,68 @@ The MCP server reads configuration from each agent's `.agent/{agent}/registry.js
 ```json
 {
   "version": "1.0.0",
-  "description": "Comprehensive configuration for Climpt MCP server and command registry",
+  "description": "Climpt comprehensive configuration for MCP server and command registry",
   "tools": {
     "availableConfigs": [
-      "code",
-      "docs",
-      "git",
-      "meta",
-      "spec",
-      "test"
+      "climpt-git",
+      "climpt-meta"
     ],
     "commands": [
-      // Git commands
       {
-        "c1": "git",
-        "c2": "create",
-        "c3": "refinement-issue",
-        "description": "Create refinement issues from requirements documents",
-        "usage": "Creates refinement issues from requirements documents.\nExample: climpt-git create refinement-issue -f requirements.md",
+        "c1": "climpt-git",
+        "c2": "decide-branch",
+        "c3": "working-branch",
+        "description": "Decide whether to create a new branch or continue on the current branch based on task content",
+        "usage": "climpt-git decide-branch working-branch",
+        "options": {
+          "edition": ["default"],
+          "adaptation": ["default"],
+          "file": false,
+          "stdin": true,
+          "destination": false
+        }
+      },
+      {
+        "c1": "climpt-git",
+        "c2": "merge-up",
+        "c3": "base-branch",
+        "description": "Merge a derived working branch back into its parent working branch",
+        "usage": "climpt-git merge-up base-branch",
+        "options": {
+          "edition": ["default"],
+          "adaptation": ["default"],
+          "file": false,
+          "stdin": false,
+          "destination": false
+        }
+      },
+      {
+        "c1": "climpt-meta",
+        "c2": "build",
+        "c3": "frontmatter",
+        "description": "Generate C3L v0.5 compliant frontmatter for Climpt instruction files",
+        "usage": "climpt-meta build frontmatter",
         "options": {
           "edition": ["default"],
           "adaptation": ["default", "detailed"],
-          "file": true,
-          "stdin": false,
+          "file": false,
+          "stdin": true,
           "destination": true
         }
       },
       {
-        "c1": "git",
-        "c2": "analyze",
-        "c3": "commit-history",
-        "description": "Analyze commit history to generate insights"
-      },
-
-      // Spec commands
-      {
-        "c1": "spec",
-        "c2": "analyze",
-        "c3": "quality-metrics",
-        "description": "Analyze specification quality and completeness"
-      },
-      {
-        "c1": "spec",
-        "c2": "validate",
-        "c3": "requirements",
-        "description": "Validate requirements against standards"
-      },
-
-      // Test commands
-      {
-        "c1": "test",
-        "c2": "execute",
-        "c3": "integration-suite",
-        "description": "Execute integration test suite"
-      },
-      {
-        "c1": "test",
-        "c2": "generate",
-        "c3": "unit-tests",
-        "description": "Generate unit tests from specifications"
-      },
-
-      // Code commands
-      {
-        "c1": "code",
+        "c1": "climpt-meta",
         "c2": "create",
-        "c3": "implementation",
-        "description": "Create implementation from design documents"
-      },
-      {
-        "c1": "code",
-        "c2": "refactor",
-        "c3": "architecture",
-        "description": "Refactor code architecture based on patterns"
-      },
-
-      // Docs commands
-      {
-        "c1": "docs",
-        "c2": "generate",
-        "c3": "api-reference",
-        "description": "Generate API reference documentation"
-      },
-      {
-        "c1": "docs",
-        "c2": "update",
-        "c3": "user-guide",
-        "description": "Update user guide documentation"
-      },
-
-      // Meta commands
-      {
-        "c1": "meta",
-        "c2": "list",
-        "c3": "available-commands",
-        "description": "List all available Climpt commands"
-      },
-      {
-        "c1": "meta",
-        "c2": "resolve",
-        "c3": "command-definition",
-        "description": "Resolve and display command definitions"
+        "c3": "instruction",
+        "description": "Create a new Climpt instruction file from stdin input, following C3L specification with all required configurations",
+        "usage": "climpt-meta create instruction",
+        "options": {
+          "edition": ["default"],
+          "adaptation": ["default", "detailed"],
+          "file": false,
+          "stdin": true,
+          "destination": true
+        }
       }
     ]
   }
@@ -452,7 +413,7 @@ The MCP server reads configuration from each agent's `.agent/{agent}/registry.js
 **Field Descriptions**:
 - `version`: Registry schema version
 - `description`: Overall registry description
-- `availableConfigs`: Array of tool names that become available as `climpt-{name}` commands
+- `availableConfigs`: Array of tool names in C3L v0.5 format (e.g., `climpt-git`, `climpt-meta`)
 - `commands`: Array of command definitions following C3L specification
   - `c1/c2/c3`: Command structure (domain/action/target)
   - `description`: Purpose of the command
@@ -471,6 +432,30 @@ cp examples/mcp/registry.template.json .agent/climpt/registry.json
 ```
 
 Complete template file available at [`examples/mcp/registry.template.json`](examples/mcp/registry.template.json)
+
+### Registry Generation
+
+Generate or update `registry.json` from prompt frontmatter:
+
+```bash
+# Via JSR (recommended)
+deno run --allow-read --allow-write --allow-env jsr:@aidevtool/climpt/reg
+
+# Local repository (using deno task)
+deno task generate-registry
+```
+
+Options:
+- `--base=<dir>` - Base directory
+- `--schema=<path>` - Schema file path
+- `--input=<pattern>` - Input glob pattern
+- `--output=<path>` - Output file path
+- `--template=<path>` - Template file path
+
+This uses `@aidevtool/frontmatter-to-schema` to:
+1. Read prompts from `.agent/climpt/prompts/**/*.md`
+2. Extract frontmatter and transform using `.agent/climpt/frontmatter-to-schema/registry.schema.json`
+3. Output to `.agent/climpt/registry.json`
 
 ### Running the MCP Server
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",
@@ -18,7 +18,8 @@
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts",
-    "./mcp": "./mcp.ts"
+    "./mcp": "./mcp.ts",
+    "./reg": "./reg.ts"
   },
   "include": [
     "README.md",
@@ -26,6 +27,7 @@
     "mod.ts",
     "cli.ts",
     "mcp.ts",
+    "reg.ts",
     "src/",
     ".agent/"
   ],

--- a/examples/prompts/list/usage/f_default.md
+++ b/examples/prompts/list/usage/f_default.md
@@ -41,7 +41,7 @@ Prompts: `.agent/climpt/prompts/**/f_*.md`
 input_text : STDIN
 input_text_file : --from, -f
 destination_path : --destination, -o
-uv-* : --uv-*
+uv-* : --uv-* (user-defined variables, e.g., --uv-scope=feature, --uv-threshold=80)
 
 ## Steps
 
@@ -84,6 +84,8 @@ input_text: Specify the current scope
 input_text_file: Receive roughly described information
 destination_path: Specify output destination with multiple files
 uv-subdomain: Specify subdomain prefix
+uv-scope: Scope of changes (e.g., 'feature', 'bugfix')
+uv-threshold: Quality threshold percentage (e.g., '80')
 `````
 
 ```:NG, 2 prompt files in one line.

--- a/reg.ts
+++ b/reg.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env
+
+/**
+ * @module
+ * Registry Generation CLI for Climpt
+ *
+ * This module generates registry.json from prompt frontmatter using
+ * @aidevtool/frontmatter-to-schema.
+ *
+ * ## Usage
+ *
+ * ### Via JSR (recommended)
+ *
+ * ```bash
+ * deno run --allow-read --allow-write --allow-env jsr:@aidevtool/climpt/reg
+ * ```
+ *
+ * ### With Options
+ *
+ * ```bash
+ * deno run --allow-read --allow-write --allow-env jsr:@aidevtool/climpt/reg \
+ *   --output=./custom-registry.json
+ * ```
+ *
+ * ## Options
+ *
+ * - `--base=<dir>` - Base directory (default: current directory)
+ * - `--schema=<path>` - Schema file path
+ * - `--input=<pattern>` - Input glob pattern
+ * - `--output=<path>` - Output file path
+ * - `--template=<path>` - Template file path
+ *
+ * ## Default Paths
+ *
+ * When run from project root, uses these defaults:
+ * - Schema: .agent/climpt/frontmatter-to-schema/registry.schema.json
+ * - Input: .agent/climpt/prompts/**\/*.md
+ * - Output: .agent/climpt/registry.json
+ * - Template: .agent/climpt/frontmatter-to-schema/registry.template.json
+ *
+ * @example
+ * ```typescript
+ * import { generateRegistry } from "jsr:@aidevtool/climpt/reg";
+ *
+ * const result = await generateRegistry({
+ *   output: "./custom-registry.json"
+ * });
+ * console.log(`Processed ${result.processedDocuments} documents`);
+ * ```
+ */
+
+import { main } from "./src/reg/index.ts";
+
+export { generateRegistry } from "./src/reg/index.ts";
+export type { GenerateOptions, GenerateResult } from "./src/reg/index.ts";
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,76 @@ async function importBreakdown(): Promise<void> {
 }
 
 /**
+ * Display Climpt help message
+ * @internal
+ */
+function showHelp(): void {
+  console.log(
+    `Climpt v${CLIMPT_VERSION} - AI-Assisted Development Instruction Tool
+
+A CLI wrapper around the @tettuan/breakdown JSR package for managing prompts
+and AI interactions.
+
+Usage:
+  climpt [command] [options]
+  climpt-<profile> <directive> <layer> [options]
+
+Basic Commands:
+  init                    Initialize breakdown configuration
+  --help, -h              Show this help message
+  --version, -v           Show Climpt and Breakdown version information
+
+Command Syntax:
+  climpt-<profile> <directive> <layer> [options]
+
+  Components:
+    <profile>    Profile name (e.g., git, breakdown, build)
+    <directive>  Action to execute (e.g., create, analyze, trace)
+    <layer>      Target layer (e.g., refinement-issue, quality-metrics)
+    [options]    Various options
+
+Options:
+  Input/Output:
+    -f, --from=<file>           Specify input file
+    -o, --destination=<path>    Specify output destination
+    (STDIN)                     Receive data from standard input
+
+  Processing Mode:
+    -e, --edition=<layer>       Specify input layer type (default: "default")
+    -a, --adaptation=<type>     Specify prompt type/variation
+
+  Custom Variables:
+    --uv-<name>=<value>         Define user variables (e.g., --uv-max-line-num=100)
+
+  System:
+    --config=<prefix>           Use custom config prefix
+    --help, -h                  Show this help message
+    --version, -v               Show version information
+
+Examples:
+  # Initialize configuration
+  climpt init
+
+  # Create refinement issue from requirements
+  climpt-git create refinement-issue -f=requirements.md -o=./issues/
+
+  # Break down issue to tasks
+  climpt-breakdown to task -e=issue -f=issue.md -a=detailed --uv-storypoint=5
+
+  # Generate from standard input
+  echo "error log" | climpt-diagnose trace stack -e=test -o=./output
+
+MCP Server:
+  Climpt supports Model Context Protocol (MCP) for AI assistant integration.
+  For details: https://jsr.io/@aidevtool/climpt
+
+Documentation:
+  https://github.com/tettuan/climpt
+`,
+  );
+}
+
+/**
  * Main entry point for the Climpt CLI application.
  *
  * This function serves as the primary interface for executing Climpt commands.
@@ -125,76 +195,6 @@ async function importBreakdown(): Promise<void> {
  * await main(["--help"]);
  * ```
  */
-/**
- * Display Climpt help message
- * @internal
- */
-function showHelp(): void {
-  console.log(
-    `Climpt v${CLIMPT_VERSION} - AI-Assisted Development Instruction Tool
-
-A CLI wrapper around the @tettuan/breakdown JSR package for managing prompts
-and AI interactions.
-
-Usage:
-  climpt [command] [options]
-  climpt-<profile> <directive> <layer> [options]
-
-Basic Commands:
-  init                    Initialize breakdown configuration
-  --help, -h              Show this help message
-  --version, -v           Show Climpt and Breakdown version information
-
-Command Syntax:
-  climpt-<profile> <directive> <layer> [options]
-
-  Components:
-    <profile>    Profile name (e.g., git, breakdown, build)
-    <directive>  Action to execute (e.g., create, analyze, trace)
-    <layer>      Target layer (e.g., refinement-issue, quality-metrics)
-    [options]    Various options
-
-Options:
-  Input/Output:
-    -f, --from=<file>           Specify input file
-    -o, --destination=<path>    Specify output destination
-    (STDIN)                     Receive data from standard input
-
-  Processing Mode:
-    -e, --edition=<layer>       Specify input layer type (default: "default")
-    -a, --adaptation=<type>     Specify prompt type/variation
-
-  Custom Variables:
-    --uv-<name>=<value>         Define user variables (e.g., --uv-max-line-num=100)
-
-  System:
-    --config=<prefix>           Use custom config prefix
-    --help, -h                  Show this help message
-    --version, -v               Show version information
-
-Examples:
-  # Initialize configuration
-  climpt init
-
-  # Create refinement issue from requirements
-  climpt-git create refinement-issue -f=requirements.md -o=./issues/
-
-  # Break down issue to tasks
-  climpt-breakdown to task -e=issue -f=issue.md -a=detailed --uv-storypoint=5
-
-  # Generate from standard input
-  echo "error log" | climpt-diagnose trace stack -e=test -o=./output
-
-MCP Server:
-  Climpt supports Model Context Protocol (MCP) for AI assistant integration.
-  For details: https://jsr.io/@aidevtool/climpt
-
-Documentation:
-  https://github.com/tettuan/climpt
-`,
-  );
-}
-
 export async function main(_args: string[] = []): Promise<void> {
   try {
     // Handle help argument

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -63,6 +63,14 @@ export interface Command {
      * Whether this command supports destination output via -d/--destination flag
      */
     destination?: boolean;
+
+    /**
+     * User-defined variables that can be passed via --uv-* options
+     * @example { "max-line-num": "Maximum lines per file", "storypoint": "Story point estimation" }
+     */
+    uv?: {
+      [name: string]: string;
+    };
   };
 }
 

--- a/src/reg/index.ts
+++ b/src/reg/index.ts
@@ -1,0 +1,292 @@
+/**
+ * Registry Generation Module
+ *
+ * Generates registry.json from prompt frontmatter using @aidevtool/frontmatter-to-schema.
+ */
+
+import { transformFiles } from "@aidevtool/frontmatter-to-schema";
+
+/**
+ * Options for registry generation
+ */
+export interface GenerateOptions {
+  /** Base directory (defaults to Deno.cwd()) */
+  baseDir?: string;
+  /** Path to schema file */
+  schema?: string;
+  /** Glob pattern for input files */
+  input?: string;
+  /** Output file path */
+  output?: string;
+  /** Template file path */
+  template?: string;
+}
+
+/**
+ * Result from registry generation
+ */
+export interface GenerateResult {
+  /** Number of documents processed */
+  processedDocuments: number;
+  /** Path to the output file */
+  outputPath: string;
+  /** Execution time in milliseconds */
+  executionTime: number;
+}
+
+/**
+ * Default paths relative to baseDir
+ */
+const DEFAULTS = {
+  schema: ".agent/climpt/frontmatter-to-schema/registry.schema.json",
+  input: ".agent/climpt/prompts/**/*.md",
+  output: ".agent/climpt/registry.json",
+  template: ".agent/climpt/frontmatter-to-schema/registry.template.json",
+};
+
+/**
+ * JSR package paths for fallback (relative to src/reg/index.ts)
+ */
+const JSR_PATHS = {
+  schema: "../../.agent/climpt/frontmatter-to-schema/registry.schema.json",
+  template: "../../.agent/climpt/frontmatter-to-schema/registry.template.json",
+};
+
+/**
+ * Check if a local file exists
+ */
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch file from JSR package and save to temp directory
+ *
+ * Handles both file:// (local) and https:// (JSR) URLs.
+ *
+ * @param jsrRelativePath - Relative path from this module to the file in JSR package
+ * @param filename - Filename for the temp file
+ * @returns Path to the temp file
+ */
+async function fetchFromJsr(
+  jsrRelativePath: string,
+  filename: string,
+): Promise<string> {
+  const url = import.meta.resolve(jsrRelativePath);
+
+  let content: string;
+
+  if (url.startsWith("file://")) {
+    // Local file:// URL - read directly
+    const filePath = new URL(url).pathname;
+    content = await Deno.readTextFile(filePath);
+  } else {
+    // Remote URL (JSR) - use fetch
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${url}: ${response.status}`);
+    }
+    content = await response.text();
+  }
+
+  const tempDir = await Deno.makeTempDir({ prefix: "climpt_reg_" });
+  const tempPath = `${tempDir}/${filename}`;
+
+  await Deno.writeTextFile(tempPath, content);
+  return tempPath;
+}
+
+/**
+ * Resolve file path with JSR fallback
+ *
+ * @param localPath - Local file path to try first
+ * @param jsrPath - JSR relative path for fallback
+ * @param filename - Filename for temp file
+ * @returns Resolved file path (local or temp)
+ */
+async function resolveWithFallback(
+  localPath: string,
+  jsrPath: string,
+  filename: string,
+): Promise<{ path: string; isTemp: boolean }> {
+  if (await fileExists(localPath)) {
+    return { path: localPath, isTemp: false };
+  }
+
+  console.log(`  Local file not found: ${localPath}`);
+  console.log(`  Fetching from JSR package...`);
+
+  const tempPath = await fetchFromJsr(jsrPath, filename);
+  return { path: tempPath, isTemp: true };
+}
+
+/**
+ * Clean up temp files
+ */
+async function cleanupTemp(paths: { path: string; isTemp: boolean }[]) {
+  for (const { path, isTemp } of paths) {
+    if (isTemp) {
+      try {
+        const dir = path.substring(0, path.lastIndexOf("/"));
+        await Deno.remove(dir, { recursive: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+}
+
+/**
+ * Generate registry.json from prompt frontmatter
+ *
+ * If schema or template files are not found locally,
+ * they will be fetched from the JSR package as fallback.
+ *
+ * @param options - Generation options
+ * @returns Result with processed documents count and output path
+ */
+export async function generateRegistry(
+  options: GenerateOptions = {},
+): Promise<GenerateResult> {
+  const baseDir = options.baseDir ?? Deno.cwd();
+
+  const localSchema = options.schema ?? `${baseDir}/${DEFAULTS.schema}`;
+  const localTemplate = options.template ?? `${baseDir}/${DEFAULTS.template}`;
+  const input = options.input ?? `${baseDir}/${DEFAULTS.input}`;
+  const output = options.output ?? `${baseDir}/${DEFAULTS.output}`;
+
+  // Resolve schema and template with JSR fallback
+  const tempPaths: { path: string; isTemp: boolean }[] = [];
+
+  let schema: string;
+  let template: string;
+
+  try {
+    const schemaResolved = await resolveWithFallback(
+      localSchema,
+      JSR_PATHS.schema,
+      "registry.schema.json",
+    );
+    tempPaths.push(schemaResolved);
+    schema = schemaResolved.path;
+
+    const templateResolved = await resolveWithFallback(
+      localTemplate,
+      JSR_PATHS.template,
+      "registry.template.json",
+    );
+    tempPaths.push(templateResolved);
+    template = templateResolved.path;
+
+    const result = await transformFiles({
+      schema,
+      input,
+      output,
+      template,
+    });
+
+    if (result.isOk()) {
+      return result.unwrap();
+    } else {
+      throw new Error(`Registry generation failed: ${result}`);
+    }
+  } finally {
+    await cleanupTemp(tempPaths);
+  }
+}
+
+/**
+ * Parse CLI arguments
+ */
+function parseArgs(args: string[]): GenerateOptions {
+  const options: GenerateOptions = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      Deno.exit(0);
+    }
+
+    if (arg.startsWith("--")) {
+      const [key, value] = arg.slice(2).split("=");
+      if (value) {
+        switch (key) {
+          case "base":
+            options.baseDir = value;
+            break;
+          case "schema":
+            options.schema = value;
+            break;
+          case "input":
+            options.input = value;
+            break;
+          case "output":
+            options.output = value;
+            break;
+          case "template":
+            options.template = value;
+            break;
+        }
+      }
+    }
+  }
+
+  return options;
+}
+
+/**
+ * Print help message
+ */
+function printHelp() {
+  console.log(`
+Usage: deno run jsr:@aidevtool/climpt/reg [options]
+
+Generate registry.json from prompt frontmatter.
+
+Options:
+  --base=<dir>       Base directory (default: current directory)
+  --schema=<path>    Schema file path
+  --input=<pattern>  Input glob pattern
+  --output=<path>    Output file path
+  --template=<path>  Template file path
+  -h, --help         Show this help
+
+If schema or template files are not found locally, they will be
+fetched from the JSR package automatically.
+
+Examples:
+  # Use defaults (run from project root)
+  deno run --allow-read --allow-write --allow-env jsr:@aidevtool/climpt/reg
+
+  # Custom output path
+  deno run --allow-read --allow-write --allow-env jsr:@aidevtool/climpt/reg --output=./registry.json
+`);
+}
+
+/**
+ * Main CLI entry point
+ */
+export async function main(args: string[] = Deno.args) {
+  const options = parseArgs(args);
+
+  console.log("Generating registry.json from prompt frontmatter...");
+
+  try {
+    const { processedDocuments, outputPath, executionTime } =
+      await generateRegistry(options);
+    console.log(`\nSuccess! Generated registry.json`);
+    console.log(`  Processed: ${processedDocuments} documents`);
+    console.log(`  Output: ${outputPath}`);
+    console.log(`  Time: ${executionTime}ms`);
+  } catch (error) {
+    console.error(`\nError:`, error);
+    Deno.exit(1);
+  }
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.8.1";
+export const CLIMPT_VERSION = "1.8.2";
 
 /**
  * Version of the breakdown package to use.

--- a/tests/mcp/test-uv-options.ts
+++ b/tests/mcp/test-uv-options.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-net --allow-env --allow-run
+
+/**
+ * Test MCP describe tool returns userVariables (uv-* options)
+ * Verifies that registry.json userVariables are included in describe results
+ */
+
+const cmd = new Deno.Command("deno", {
+  args: [
+    "run",
+    "--allow-read",
+    "--allow-write",
+    "--allow-net",
+    "--allow-env",
+    "--allow-run",
+    "./src/mcp/index.ts",
+  ],
+  stdin: "piped",
+  stdout: "piped",
+  stderr: "piped",
+});
+
+console.log("🔧 Testing MCP describe returns userVariables (uv-* options)...");
+
+const process = cmd.spawn();
+const writer = process.stdin.getWriter();
+
+// Initialize
+const initMessage = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "uv-options-test-client", version: "1.0.0" },
+  },
+}) + "\n";
+
+await writer.write(new TextEncoder().encode(initMessage));
+
+// Describe tool call for command with userVariables
+const describeMessage = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 2,
+  method: "tools/call",
+  params: {
+    name: "describe",
+    arguments: {
+      c1: "git",
+      c2: "group-commit",
+      c3: "unstaged-changes",
+    },
+  },
+}) + "\n";
+
+const reader = process.stdout.getReader();
+const errorReader = process.stderr.getReader();
+
+// Read stderr
+const readStderr = async () => {
+  try {
+    while (true) {
+      const { value, done } = await errorReader.read();
+      if (done) break;
+      const text = new TextDecoder().decode(value);
+      console.log("🐛 STDERR:", text.trim());
+    }
+  } catch (e) {
+    console.log("Error reading stderr:", e);
+  }
+};
+
+readStderr();
+
+let buffer = "";
+let initReceived = false;
+
+setTimeout(async () => {
+  console.log("⏱️ Timeout - closing connection");
+  await writer.close();
+  process.kill();
+  Deno.exit(1);
+}, 15000);
+
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+
+  buffer += new TextDecoder().decode(value);
+  const lines = buffer.split("\n");
+  buffer = lines[lines.length - 1];
+
+  for (let i = 0; i < lines.length - 1; i++) {
+    const line = lines[i].trim();
+    if (line) {
+      try {
+        const message = JSON.parse(line);
+
+        if (message.result && message.id === 1 && !initReceived) {
+          console.log("✅ Server initialized! Calling describe tool...");
+          initReceived = true;
+          await writer.write(new TextEncoder().encode(describeMessage));
+        }
+
+        if (message.result && message.id === 2) {
+          console.log("🎉 Describe tool call completed!");
+
+          const result = message.result;
+          if (!result.content || !Array.isArray(result.content)) {
+            console.log("❌ FAILED: Response missing 'content' array");
+            await writer.close();
+            process.kill();
+            Deno.exit(1);
+          }
+
+          const textContent = result.content[0];
+          const responseData = JSON.parse(textContent.text);
+
+          console.log("\n📋 Describe response:");
+          console.log(JSON.stringify(responseData, null, 2));
+
+          // Validate userVariables are present
+          const commands = responseData.commands;
+          if (!commands || commands.length === 0) {
+            console.log("❌ FAILED: No commands found in describe response");
+            await writer.close();
+            process.kill();
+            Deno.exit(1);
+          }
+
+          const command = commands[0];
+          const uv = command.options?.uv;
+
+          if (!uv) {
+            console.log("❌ FAILED: uv not found in describe response");
+            console.log(
+              "📄 Command options:",
+              JSON.stringify(command.options, null, 2),
+            );
+            await writer.close();
+            process.kill();
+            Deno.exit(1);
+          }
+
+          // Check for expected uv variables
+          if (!uv.scope || !uv.prefix) {
+            console.log(
+              "❌ FAILED: Expected uv 'scope' and 'prefix' not found",
+            );
+            console.log("📄 uv:", JSON.stringify(uv, null, 2));
+            await writer.close();
+            process.kill();
+            Deno.exit(1);
+          }
+
+          console.log("\n✅ SUCCESS: uv found in describe response");
+          console.log("📄 uv:");
+          console.log(`  - scope: ${uv.scope}`);
+          console.log(`  - prefix: ${uv.prefix}`);
+
+          await writer.close();
+          process.kill();
+          Deno.exit(0);
+        }
+
+        if (message.error) {
+          console.log("❌ Error received:", message.error);
+          await writer.close();
+          process.kill();
+          Deno.exit(1);
+        }
+      } catch (e) {
+        console.log("⚠️ Error parsing JSON:", e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Release v1.8.2

### New Features
- Add `./reg` export for JSR-based registry generation (`jsr:@aidevtool/climpt/reg`)
- Implement fallback mechanism that fetches schema/template from JSR package when local files don't exist
- Add `uv` options support to MCP describe

### Improvements
- Add JSDoc documentation to main function exports for JSR compliance

### Files Changed
- `reg.ts` - New entry point for registry generation
- `src/reg/index.ts` - Core logic with fallback mechanism
- `deno.json` - Add `./reg` export
- `README.md` - Updated documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)