### PR TITLE
fix: improve registry generation after init (v1.9.5)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/reg/index.ts
+++ b/src/reg/index.ts
@@ -211,7 +211,16 @@ export async function generateRegistry(
     if (result.isOk()) {
       return result.unwrap();
     } else {
-      throw new Error(`Registry generation failed: ${result}`);
+      // Result type may have different error extraction methods
+      const err = typeof result.unwrapErr === "function"
+        ? result.unwrapErr()
+        : result.error ?? result;
+      const errorMessage = err instanceof Error
+        ? err.message
+        : typeof err === "string"
+        ? err
+        : JSON.stringify(err, null, 2);
+      throw new Error(`Registry generation failed: ${errorMessage}`);
     }
   } finally {
     await cleanupTemp(tempPaths);

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.9.4";
+export const CLIMPT_VERSION = "1.9.5";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Add complete C3L schema embedding with required x- attributes (x-frontmatter-part, x-derived-from, etc.)
- Fix error handling to show detailed errors instead of [object Object]
- Use hardcoded version/description in registry template
- Bump version to 1.9.5

## Test plan
- [x] deno task ci passed (71 tests)
- [x] Verified `climpt init` + `climpt reg` works correctly