### PR TITLE
Merge develop to main: v1.9.9

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/iterate-agent/README.md
+++ b/iterate-agent/README.md
@@ -29,18 +29,8 @@ development tasks by:
 
 1. **Deno 2.x** (latest version required)
 2. **GitHub CLI (`gh`)** - [Installation guide](https://cli.github.com/manual/)
-3. **GITHUB_TOKEN** environment variable with `repo` and `project` scopes
 
 ## Quick Start
-
-### 1. Setup Environment
-
-```bash
-# Set GitHub token
-export GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxx"
-```
-
-### 2. Run the Agent
 
 ```bash
 # Work on Issue #123 until closed (uses default agent "climpt")
@@ -224,14 +214,6 @@ brew install gh
 
 # Linux
 # See https://cli.github.com/manual/installation
-```
-
-### Error: "GITHUB_TOKEN not found"
-
-Set the environment variable:
-
-```bash
-export GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxx"
 ```
 
 ### Error: "Configuration file not found"

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.9.5";
+export const CLIMPT_VERSION = "1.9.9";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
Release v1.9.9 to main

## Changes included
- docs: remove GITHUB_TOKEN references from iterate-agent README
- chore: bump version to 1.9.9
- fix: exclude stdin from CLI args and pipe LLM-generated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)