### PR TITLE
fix: remove leading ./ from plugin source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
         "name": "tettuan",
         "url": "https://github.com/tettuan"
       },
-      "source": "./climpt-agent",
+      "source": "climpt-agent",
       "category": "development"
     }
   ]


### PR DESCRIPTION
## Summary
- Remove leading `./` from plugin source path in marketplace.json
- Source path should be relative to `pluginRoot` without leading `./`

🤖 Generated with [Claude Code](https://claude.com/claude-code)