### PR TITLE
Release 1.9.13: version bump and CI check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**']
   pull_request:
     branches: [main, develop]
 
@@ -30,3 +30,30 @@ jobs:
       
       - name: Run tests
         run: deno test --allow-all
+
+      - name: Check version consistency
+        run: |
+          # Extract versions
+          DENO_VERSION=$(grep '"version"' deno.json | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+          TS_VERSION=$(grep 'export const CLIMPT_VERSION' src/version.ts | sed 's/.*= *"\([^"]*\)".*/\1/')
+
+          echo "deno.json version: $DENO_VERSION"
+          echo "version.ts version: $TS_VERSION"
+
+          # Check deno.json and version.ts match
+          if [ "$DENO_VERSION" != "$TS_VERSION" ]; then
+            echo "::error::Version mismatch: deno.json=$DENO_VERSION, version.ts=$TS_VERSION"
+            exit 1
+          fi
+
+          # For release branches, check branch name matches version
+          if [[ "$GITHUB_REF" == refs/heads/release/* ]]; then
+            BRANCH_VERSION=${GITHUB_REF#refs/heads/release/}
+            echo "Branch version: $BRANCH_VERSION"
+            if [ "$BRANCH_VERSION" != "$DENO_VERSION" ]; then
+              echo "::error::Branch version mismatch: branch=$BRANCH_VERSION, deno.json=$DENO_VERSION"
+              exit 1
+            fi
+          fi
+
+          echo "✓ Version consistency check passed"

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.9.12";
+export const CLIMPT_VERSION = "1.9.13";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Bump version to 1.9.13
- Add CI version consistency check for release branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)