### PR TITLE
docs: add release-procedure skill

### DIFF
--- a/.claude/skills/release-procedure/SKILL.md
+++ b/.claude/skills/release-procedure/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: release-procedure
+description: main, develop, release/* ブランチへの push や PR マージ時にバージョンアップとリリース手順を案内する
+allowed-tools: [Bash, Read, Edit, Grep, Glob]
+---
+
+# リリース手順ガイド
+
+## 目的
+
+バージョンアップとリリースが正しい手順で行われることを担保する。
+
+## トリガー条件
+
+以下の操作について議論・作業する際に自動的に実行:
+
+- `release/*` ブランチへの push
+- `release/*` → `develop` への PR 作成・マージ
+- `develop` → `main` への PR 作成・マージ
+- バージョンアップ・リリースに関する議論
+- vtag の作成
+
+## バージョン管理ファイル
+
+このプロジェクトでは以下の2ファイルでバージョンを管理:
+
+| ファイル | 用途 |
+|---------|------|
+| `deno.json` | JSR パッケージバージョン（`"version": "x.y.z"`） |
+| `src/version.ts` | CLI バージョン定数（`CLIMPT_VERSION = "x.y.z"`） |
+
+**重要**: 両ファイルのバージョンは必ず一致させること。CIで自動チェックされる。
+
+## バージョンアップ手順
+
+### 1. バージョン番号の決定
+
+```
+パッチ (x.y.Z): バグ修正、ドキュメント改善
+マイナー (x.Y.0): 新機能追加（後方互換あり）
+メジャー (X.0.0): 破壊的変更
+```
+
+### 2. ファイル更新
+
+```bash
+# deno.json
+# "version": "1.9.13" → "version": "1.9.14"
+
+# src/version.ts
+# export const CLIMPT_VERSION = "1.9.13"; → "1.9.14";
+```
+
+### 3. 確認コマンド
+
+```bash
+# バージョン一致確認
+grep '"version"' deno.json | head -1
+grep 'CLIMPT_VERSION' src/version.ts | grep export
+```
+
+## リリースフロー
+
+### フロー図
+
+```mermaid
+sequenceDiagram
+    participant R as release/x.y.z
+    participant D as develop
+    participant M as main
+    participant T as vtag
+
+    Note over R: 1. バージョンアップ
+    R->>R: deno.json, version.ts 更新
+    R->>R: git commit & push
+
+    R->>D: 2. PR作成 (release → develop)
+    Note over D: CI確認（バージョン整合性チェック含む）
+    D->>D: 3. PRマージ
+
+    D->>M: 4. PR作成 (develop → main)
+    Note over M: CI確認
+    M->>M: 5. PRマージ
+    Note over M: JSR publish 自動実行
+
+    M->>T: 6. vtag作成
+    Note over T: git tag vx.y.z
+```
+
+### 手順詳細
+
+#### ステップ 0: 準備
+
+```bash
+# 作業ブランチを release/* に統合済みか確認
+git checkout release/x.y.z
+git log --oneline -10
+```
+
+#### ステップ 1: release/* ブランチでバージョンアップ
+
+```bash
+# develop から新規作成する場合
+git checkout develop
+git checkout -b release/x.y.z
+
+# または既存 release/* で作業
+git checkout release/x.y.z
+```
+
+deno.json と version.ts を編集:
+
+```bash
+# 編集後、確認
+grep '"version"' deno.json
+grep 'export const CLIMPT_VERSION' src/version.ts
+```
+
+#### ステップ 2: コミット & プッシュ
+
+```bash
+git add deno.json src/version.ts
+git commit -m "chore: bump version to x.y.z"
+git push -u origin release/x.y.z
+```
+
+**注意**: `dangerouslyDisableSandbox: true` が必要
+
+#### ステップ 3: release/* → develop PR
+
+```bash
+gh pr create --base develop --head release/x.y.z \
+  --title "Release x.y.z: <変更概要>" \
+  --body "## Summary
+- <変更点>
+
+## Version
+- x.y.z"
+```
+
+#### ステップ 4: CI確認 & develop へマージ
+
+```bash
+# CI確認
+gh pr checks <PR番号> --watch
+
+# マージ
+gh pr merge <PR番号> --merge
+```
+
+#### ステップ 5: develop → main PR
+
+```bash
+gh pr create --base main --head develop \
+  --title "Release x.y.z" \
+  --body "Release version x.y.z to production"
+```
+
+#### ステップ 6: CI確認 & main へマージ
+
+```bash
+gh pr checks <PR番号> --watch
+gh pr merge <PR番号> --merge
+```
+
+**自動処理**: main マージ時に JSR publish が自動実行される
+
+#### ステップ 7: vtag 作成
+
+```bash
+# main の最新コミットを取得
+git fetch origin main
+
+# vtag 作成 & push
+git tag vx.y.z origin/main
+git push origin vx.y.z
+```
+
+**重要**: vtag は必ず main ブランチのコミットに付与する
+
+#### ステップ 8: クリーンアップ
+
+```bash
+# develop に戻る
+git checkout develop
+git pull origin develop
+
+# release ブランチ削除
+git branch -d release/x.y.z
+git push origin --delete release/x.y.z
+```
+
+## CI バージョンチェック
+
+`.github/workflows/test.yml` で以下を自動チェック:
+
+1. `deno.json` と `version.ts` のバージョン一致
+2. `release/*` ブランチ名とバージョンの一致
+
+```yaml
+# release/1.9.14 ブランチでは deno.json も 1.9.14 であること
+```
+
+## クイックリファレンス
+
+```
+バージョンアップ:
+  1. deno.json の version を更新
+  2. src/version.ts の CLIMPT_VERSION を更新
+  3. git commit -m "chore: bump version to x.y.z"
+
+リリースフロー:
+  1. release/* → develop PR作成 → CI確認 → マージ
+  2. develop → main PR作成 → CI確認 → マージ (JSR publish 自動)
+  3. vtag作成: git tag vx.y.z origin/main && git push origin vx.y.z
+  4. クリーンアップ: release/* ブランチ削除
+
+サンドボックス注意:
+  git push, gh コマンドは dangerouslyDisableSandbox: true が必要
+```
+
+## トラブルシューティング
+
+### JSR publish がスキップされた
+
+原因: deno.json のバージョンが既存と同じ
+
+```bash
+# 確認
+gh run view <run-id> --log | grep -i "skip"
+
+# 対処: バージョンを上げて再リリース
+```
+
+### CI バージョンチェック失敗
+
+原因: deno.json と version.ts の不一致、またはブランチ名との不一致
+
+```bash
+# 確認
+grep '"version"' deno.json
+grep 'export const CLIMPT_VERSION' src/version.ts
+git branch --show-current
+
+# 対処: 全て同じバージョンに統一
+```
+
+### vtag が古いコミットを指している
+
+```bash
+# 確認
+git show vx.y.z --oneline
+
+# 対処: タグ削除 & 再作成
+git tag -d vx.y.z
+git push origin :refs/tags/vx.y.z
+git tag vx.y.z origin/main
+git push origin vx.y.z
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,58 +11,34 @@ Prompt呼び出しは、https://jsr.io/@tettuan/breakdown を実行する wrap �
 MCPや、呼び出し方の定義ファイルが、Climptレポジトリに存在する。
 
 # Git
-develop, main への直接pushは禁止。
-PR作成してからリモートMergeする。その後ローカル反映する。
 
-## ブランチ戦略
+develop, main への直接pushは禁止。PR作成してからリモートMergeする。
 
-詳細は `/branch-management` skill を参照。
+- ブランチ戦略: `/branch-management` skill 参照
+- リリース手順: `/release-procedure` skill 参照
 
 基本フロー: `作業ブランチ -> release/* -> develop -> main`
 
 ## サンドボックス制限
 
-Claude Code で git のネットワーク操作（push, pull, fetch, clone など）を実行する場合、ALWAYS use `dangerouslyDisableSandbox: true`:
+Claude Code で git/gh コマンドを実行する場合、`dangerouslyDisableSandbox: true` が必要:
 
 ```typescript
 Bash({
   command: "git push -u origin feature-branch",
-  description: "Push branch to remote",
   dangerouslyDisableSandbox: true,
 })
 ```
 
-**理由**: サンドボックス環境では github.com へのネットワークアクセスが制限されており、`dangerouslyDisableSandbox: true` を指定しないと `Could not resolve host: github.com` エラーが発生する。
-
-**対象コマンド**:
-- `git push`
-- `git pull`
-- `git fetch`
-- `git clone`
-- `gh` コマンド全般（GitHub CLI）
-
-# リリース手順
-
-0. release/* ブランチへ全ての作業ブランチを統合する（リリースに必要な変更に限る）
-1. リリースブランチを develop から派生して作成する（既存の release/* がある場合はそこから作業）
-2. リリース番号をあげる（deno.json, version.ts） , 基本はパッチバージョン
-3. リモートpushする
-4. リリースブランチ -> develop へのPRを作成する
-5. CIパスしていたら developへのPRマージを実施する
-6. develop -> main へのPR作成する
-7. mainへマージする
-8. main の最新コミットを特定し、vtagを付与する（必ずmainへ付与する）
+対象: `git push`, `git pull`, `git fetch`, `git clone`, `gh` コマンド全般
 
 # Iterate Agent
 
-When running iterate-agent from Claude Code, ALWAYS use `dangerouslyDisableSandbox: true`:
+Claude Agent SDK 使用時も `dangerouslyDisableSandbox: true` が必要:
 
 ```typescript
 Bash({
   command: "deno run -A jsr:@aidevtool/climpt/agents/iterator --issue 123",
-  description: "Run iterate agent for issue 123",
   dangerouslyDisableSandbox: true,
 })
 ```
-
-**理由**: Claude Agent SDK は `~/.claude/projects/`, `~/.claude/statsig/`, `~/.claude/telemetry/` などのディレクトリに書き込むため、サンドボックスの許可リストに含まれていない。`dangerouslyDisableSandbox: true` を指定しないと EPERM エラーが発生する。

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.9.14";
+export const CLIMPT_VERSION = "1.9.15";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Add `/release-procedure` skill with version bump and release workflow documentation
- Simplify CLAUDE.md to reference skills for branch strategy and release procedure
- Version bump to 1.9.15