### PR TITLE
docs: add nodeModulesDir troubleshooting for npm/pnpm projects

### DIFF
--- a/plugins/climpt-agent/README.md
+++ b/plugins/climpt-agent/README.md
@@ -38,6 +38,37 @@ If you prefer not to disable the sandbox:
 2. **Use MCP tools** - Use Climpt MCP tools directly instead of delegating to
    sub-agent
 
+## Projects with node_modules (npm/pnpm)
+
+If your project uses npm or pnpm alongside Deno tools, add this to your `deno.json`:
+
+```json
+{
+  "nodeModulesDir": "auto"
+}
+```
+
+### Why?
+
+When Deno detects a `node_modules/` directory, it switches to "manual" mode and tries to resolve npm packages from there. Since `@anthropic-ai/claude-agent-sdk` isn't in your project's node_modules, Deno fails with:
+
+```
+error: Import 'file:///path/to/project' failed.
+    0: Is a directory (os error 21)
+```
+
+Setting `"nodeModulesDir": "auto"` tells Deno to resolve npm packages independently from its own cache, ignoring the existing node_modules.
+
+### Common setup
+
+```
+your-project/
+├── deno.json          ← Add "nodeModulesDir": "auto"
+├── node_modules/      ← For React/Vite (npm/pnpm)
+├── package.json
+└── .agent/climpt/     ← Climpt prompts
+```
+
 ## Usage
 
 See [SKILL.md](skills/delegate-climpt-agent/SKILL.md) for detailed workflow

--- a/plugins/climpt-agent/skills/delegate-climpt-agent/SKILL.md
+++ b/plugins/climpt-agent/skills/delegate-climpt-agent/SKILL.md
@@ -108,6 +108,28 @@ Use when the user gives project-specific instructions and it's unclear from gene
 3. Ensure all required permissions are granted
 4. Check that registry.json exists
 
+### "Import directory failed" error
+
+If you see an error like:
+```
+error: Import 'file:///path/to/project' failed.
+    0: Is a directory (os error 21)
+```
+
+**Cause**: The project has `node_modules/` directory (from npm/pnpm), causing Deno to use "manual" mode for npm package resolution. Deno then fails to find `@anthropic-ai/claude-agent-sdk` in the local node_modules.
+
+**Solution**: Add `nodeModulesDir` setting to the project's `deno.json`:
+
+```json
+{
+  "nodeModulesDir": "auto"
+}
+```
+
+This tells Deno to resolve npm packages independently, ignoring the existing node_modules directory.
+
+**Note**: This is a host project configuration, not a climpt-agent issue. Any project using both npm/pnpm and Deno tools should include this setting
+
 ### Sub-agent errors
 The sub-agent runs independently and reports its own errors. Check:
 1. Working directory is correct


### PR DESCRIPTION
## Summary
- Add documentation for `nodeModulesDir: auto` setting in README.md
- Update SKILL.md troubleshooting section with proper solution
- Remove `--node-modules-dir=auto` flag from command examples (host project config is the correct fix)

## Problem
When a project has `node_modules/` from npm/pnpm, Deno 2.4+ switches to "manual" mode and fails to resolve climpt-agent's SDK dependency.

## Solution
Document that projects should add `"nodeModulesDir": "auto"` to their `deno.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)