### PR TITLE
Release 1.11.5

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.11.4";
+export const CLIMPT_VERSION = "1.11.5";
 
 /**
  * Version of the breakdown package to use.
@@ -37,7 +37,7 @@ export const CLIMPT_VERSION = "1.11.4";
  * const mod = await import(`jsr:@tettuan/breakdown@^${BREAKDOWN_VERSION}`);
  * ```
  */
-export const BREAKDOWN_VERSION = "1.8.0";
+export const BREAKDOWN_VERSION = "1.8.2";
 
 /**
  * Version of the frontmatter-to-schema package to use.


### PR DESCRIPTION
## Summary
Release version 1.11.5 to production.

## Changes
- Update `@tettuan/breakdown` from 1.8.0 to 1.8.2
- Fix retry-handler tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)