### PR TITLE
Release 1.11.8: Step-level model selection docs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -140,6 +140,8 @@ deno task agent --init --agent {agent-name}
 
 テンプレートファイルを含むディレクトリ構成が生成されます。
 
+**ビルダードキュメント**: エージェント設定とカスタマイズの詳細ガイドは [`agents/docs/builder/`](agents/docs/builder/) を参照。
+
 ### エージェント実行
 
 ```bash
@@ -160,13 +162,14 @@ deno task agent --agent {name} --iterate-max 10
 
 | タイプ | 説明 |
 |--------|------|
-| `issue` | GitHub Issue がクローズされたら完了 |
-| `project` | GitHub Project から複数の Issue を処理 |
-| `iterate` | 指定回数（`maxIterations`）反復実行 |
-| `manual` | エージェントが `completionKeyword` を出力したら終了 |
+| `externalState` | 外部リソース状態を監視（GitHub issue/project、ファイル、API） |
+| `iterationBudget` | 指定回数（`maxIterations`）反復実行 |
+| `checkBudget` | 指定回数（`maxChecks`）ステータス確認 |
+| `keywordSignal` | エージェントが `completionKeyword` を出力したら終了 |
+| `structuredSignal` | 構造化アクションブロック出力を検出（`signalType`） |
+| `stepMachine` | ステップステートマシンに従う（`registryPath`, `entryStep`） |
+| `composite` | 複合条件（and/or/first演算子） |
 | `custom` | カスタムハンドラー（`handlerPath`）を使用 |
-| `facilitator` | プロジェクト状況を定期的に監視 |
-| `stepFlow` | ステップベースの実行フローに従う |
 
 ### 組み込みエージェント
 
@@ -184,6 +187,18 @@ deno run -A jsr:@aidevtool/climpt/agents/reviewer --project 1
 ```bash
 deno run -A jsr:@aidevtool/climpt/agents/facilitator --project 1
 ```
+
+### ドキュメント
+
+| ドキュメント | パス | 説明 |
+|-------------|------|------|
+| クイックスタート | `agents/docs/builder/01_quickstart.md` | エージェント作成ガイド |
+| 定義リファレンス | `agents/docs/builder/02_agent_definition.md` | agent.json フィールド |
+| トラブルシューティング | `agents/docs/builder/05_troubleshooting.md` | よくある問題と解決策 |
+| 設計ドキュメント | `agents/docs/design/` | アーキテクチャとコンセプト |
+| JSON スキーマ | `agents/schemas/` | agent.schema.json, steps_registry.schema.json |
+
+CLIオプションは `deno task agent --help` を参照。
 
 ### 設定例
 
@@ -240,8 +255,8 @@ Climptは `.agent/climpt/config/` に2つの設定ファイルを使用：
 # 全ドキュメントをインストール
 dx jsr:@aidevtool/climpt/docs
 
-# 日本語ガイドのみインストール
-dx jsr:@aidevtool/climpt/docs install ./docs --category=guides --lang=ja
+# 英語ガイドのみインストール
+dx jsr:@aidevtool/climpt/docs install ./docs --category=guides --lang=en
 
 # 1ファイルに結合
 dx jsr:@aidevtool/climpt/docs install ./docs --mode=single

--- a/README.md
+++ b/README.md
@@ -162,13 +162,14 @@ deno task agent --agent {name} --iterate-max 10
 
 | Type | Description |
 |------|-------------|
-| `issue` | Completes when GitHub Issue is closed |
-| `project` | Processes multiple Issues from GitHub Project |
-| `iterate` | Runs for specified iterations (`maxIterations`) |
-| `manual` | Exits when agent outputs `completionKeyword` |
+| `externalState` | Monitors external resource state (GitHub issue/project, file, API) |
+| `iterationBudget` | Runs for specified iterations (`maxIterations`) |
+| `checkBudget` | Runs for specified status checks (`maxChecks`) |
+| `keywordSignal` | Exits when agent outputs `completionKeyword` |
+| `structuredSignal` | Detects structured action block output (`signalType`) |
+| `stepMachine` | Follows step state machine (`registryPath`, `entryStep`) |
+| `composite` | Combined conditions with operator (and/or/first) |
 | `custom` | Uses custom handler (`handlerPath`) |
-| `facilitator` | Monitors project status periodically |
-| `stepFlow` | Follows step-based execution flow |
 
 ### Built-in Agents
 
@@ -254,8 +255,8 @@ Install docs locally as markdown:
 # Install all docs
 dx jsr:@aidevtool/climpt/docs
 
-# Install Japanese guides only
-dx jsr:@aidevtool/climpt/docs install ./docs --category=guides --lang=ja
+# Install English guides only
+dx jsr:@aidevtool/climpt/docs install ./docs --category=guides --lang=en
 
 # Combine into single file
 dx jsr:@aidevtool/climpt/docs install ./docs --mode=single

--- a/agents/docs/INDEX.md
+++ b/agents/docs/INDEX.md
@@ -20,6 +20,7 @@ Flow/Completion の哲学、境界、C3L、Structured Output など、すべて�
 | `design/06_contracts.md`          | StepContext や CompletionChain の契約、I/O、失敗条件。      |
 | `design/07_extension_points.md`   | 差し替え可能な拡張ポイントと制約。                          |
 | `design/08_step_flow_design.md`   | Flow Step の strict gate 仕様と handoff 設計。              |
+| `design/09_model_selection.md`    | ステップごとのモデル選択と解決優先順位。                    |
 
 ## 汎用 Agentを利用したエージェント追加方法
 

--- a/agents/docs/builder/01_quickstart.md
+++ b/agents/docs/builder/01_quickstart.md
@@ -523,6 +523,28 @@ Flow 終了シーケンス:
 | `structuredGate`   | AI 応答から intent 抽出 |
 | `transitions`      | intent → 次の Step      |
 | `handoffFields`    | 次 Step へ渡すデータ    |
+| `model`            | 使用モデル（任意）      |
+
+#### model フィールド（任意）
+
+ステップごとに使用するモデルを指定できる。省略時は opus（システムデフォルト）。
+
+```json
+{
+  "initial.default": {
+    "stepId": "initial.default",
+    "model": "haiku"
+  }
+}
+```
+
+| 値       | 用途                         |
+| -------- | ---------------------------- |
+| `opus`   | デフォルト。重要な判断       |
+| `sonnet` | コストと品質のバランス       |
+| `haiku`  | 定型処理、リトライ、繰り返し |
+
+詳細: [design/09_model_selection.md](../design/09_model_selection.md)
 
 #### structuredGate フィールド
 
@@ -772,3 +794,4 @@ Error: Prompt file not found: prompts/steps/initial/default/f_default.md
 | [design/02_prompt_system.md](../design/02_prompt_system.md)           | C3L プロンプト解決 |
 | [design/03_structured_outputs.md](../design/03_structured_outputs.md) | Structured Output  |
 | [design/08_step_flow_design.md](../design/08_step_flow_design.md)     | Step Flow 設計     |
+| [design/09_model_selection.md](../design/09_model_selection.md)       | モデル選択設計     |

--- a/agents/docs/builder/02_agent_definition.md
+++ b/agents/docs/builder/02_agent_definition.md
@@ -35,6 +35,29 @@ Agent の振る舞い。
 }
 ```
 
+### defaultModel
+
+使用するモデルのデフォルト値。省略時は `opus`（システムデフォルト）。
+
+```json
+{
+  "behavior": {
+    "defaultModel": "sonnet"
+  }
+}
+```
+
+| 値       | 説明                           |
+| -------- | ------------------------------ |
+| `opus`   | 最高性能（システムデフォルト） |
+| `sonnet` | 高性能・バランス               |
+| `haiku`  | 高速・低コスト                 |
+
+**通常は設定不要**。opus がデフォルトのため、エージェント全体で異なるモデルを
+使いたい場合のみ指定する。ステップごとの指定は `steps_registry.json` で行う。
+
+詳細: [design/09_model_selection.md](../design/09_model_selection.md)
+
 ### completionType
 
 | タイプ             | What                                      | Why                                                       | 主な設定                                   |
@@ -267,3 +290,4 @@ load(path) → parse → validate → 起動 or エラー
 | [03_builder_guide.md](./03_builder_guide.md)                          | 設計思想と連鎖              |
 | [04_config_system.md](./04_config_system.md)                          | 設定の優先順位              |
 | [design/03_structured_outputs.md](../design/03_structured_outputs.md) | completionConditions の詳細 |
+| [design/09_model_selection.md](../design/09_model_selection.md)       | モデル選択の設計            |

--- a/agents/docs/design/09_model_selection.md
+++ b/agents/docs/design/09_model_selection.md
@@ -1,0 +1,204 @@
+# Model Selection
+
+ステップごとに使用するモデルを指定できる仕組み。品質とコストのバランスを
+ステップ単位で制御する。
+
+## Why
+
+- **品質重視のデフォルト**: 明示的に指定しない限り opus を使用
+- **コスト最適化**: 定型的なステップには haiku を指定可能
+- **シンプルな設定**: 多くのステップは設定不要
+
+## What
+
+### 利用可能なモデル
+
+| モデル   | 特徴             | 用途                               |
+| -------- | ---------------- | ---------------------------------- |
+| `opus`   | 最高性能         | デフォルト。初期分析、重要な判断   |
+| `sonnet` | 高性能・バランス | コストと品質のバランスが必要な場合 |
+| `haiku`  | 高速・低コスト   | 定型処理、リトライ、繰り返し作業   |
+
+### 解決優先順位
+
+```
+1. step.model             (ステップ固有の指定)
+2. behavior.defaultModel  (エージェントのデフォルト)
+3. "opus"                 (システムデフォルト)
+```
+
+Runner は上から順に評価し、最初に見つかった値を使用する。
+
+## 設定
+
+### agent.json - defaultModel（通常不要）
+
+システムデフォルトが opus のため、通常は設定不要。 エージェント全体で opus
+以外をデフォルトにしたい場合のみ指定。
+
+```json
+{
+  "behavior": {
+    "defaultModel": "sonnet"
+  }
+}
+```
+
+### steps_registry.json - ステップごとの指定
+
+例外的なステップのみ `model` を指定する。
+
+```json
+{
+  "steps": {
+    "initial.issue": {
+      "stepId": "initial.issue"
+      // model 未指定 → opus (default)
+    },
+    "continuation.issue": {
+      "stepId": "continuation.issue",
+      "model": "haiku"
+    },
+    "closure.issue": {
+      "stepId": "closure.issue",
+      "model": "haiku"
+    }
+  }
+}
+```
+
+## 実装
+
+### Runner の resolveModelForStep
+
+```typescript
+private resolveModelForStep(stepId?: string): ModelName {
+  const SYSTEM_DEFAULT: ModelName = "opus";
+
+  // 1. ステップ固有の指定
+  if (stepId && this.stepsRegistry) {
+    const stepDef = this.stepsRegistry.steps[stepId];
+    if (stepDef?.model) {
+      return stepDef.model;
+    }
+  }
+
+  // 2. エージェントのデフォルト
+  if (this.definition.behavior.defaultModel) {
+    return this.definition.behavior.defaultModel;
+  }
+
+  // 3. システムデフォルト
+  return SYSTEM_DEFAULT;
+}
+```
+
+### SDK への受け渡し
+
+```typescript
+const queryOptions = {
+  model: this.resolveModelForStep(stepId),
+  // ...
+};
+
+const queryIterator = query({ prompt, options: queryOptions });
+```
+
+## ステップ種別ごとの推奨
+
+| ステップ種別     | 推奨モデル     | 理由                         |
+| ---------------- | -------------- | ---------------------------- |
+| `initial.*`      | opus (default) | 初期分析・方針決定は品質重視 |
+| `continuation.*` | haiku or opus  | 繰り返し作業はコスト考慮可   |
+| `closure.*`      | haiku          | 定型的なクロージング処理     |
+| `*.review`       | opus (default) | レビューは品質重視           |
+| `retry.*`        | haiku          | リトライは高速優先           |
+
+## 使用例
+
+### 1. 標準設定（全て opus）
+
+```json
+{
+  "steps": {
+    "initial.issue": {},
+    "continuation.issue": {},
+    "closure.issue": {}
+  }
+}
+```
+
+### 2. コスト最適化
+
+```json
+{
+  "steps": {
+    "initial.issue": {},
+    "continuation.issue": { "model": "haiku" },
+    "closure.issue": { "model": "haiku" }
+  }
+}
+```
+
+### 3. バランス型
+
+```json
+// agent.json
+{ "behavior": { "defaultModel": "sonnet" } }
+
+// steps_registry.json
+{
+  "steps": {
+    "initial.issue": { "model": "opus" },
+    "continuation.issue": {},
+    "closure.issue": {}
+  }
+}
+```
+
+## ログ出力
+
+```
+[Model] Step "initial.issue" using model: opus (source: system)
+[Model] Step "continuation.issue" using model: haiku (source: step)
+```
+
+## 型定義
+
+```typescript
+// src_common/types.ts
+export type ModelName = "sonnet" | "opus" | "haiku";
+
+export interface AgentBehavior {
+  defaultModel?: ModelName;
+  // ...
+}
+
+// common/step-registry.ts
+export interface PromptStepDefinition {
+  model?: ModelName;
+  // ...
+}
+```
+
+## バリデーション
+
+```typescript
+const VALID_MODELS = ["sonnet", "opus", "haiku"] as const;
+
+function validateStepModel(step: PromptStepDefinition): void {
+  if (step.model && !VALID_MODELS.includes(step.model)) {
+    throw new Error(
+      `Invalid model "${step.model}" for step "${step.stepId}". ` +
+        `Valid models: ${VALID_MODELS.join(", ")}`,
+    );
+  }
+}
+```
+
+## 関連ドキュメント
+
+| ドキュメント                                                        | 内容                          |
+| ------------------------------------------------------------------- | ----------------------------- |
+| [01_runner.md](./01_runner.md)                                      | Runner の責務と実行シーケンス |
+| [builder/02_agent_definition.md](../builder/02_agent_definition.md) | agent.json の設定詳細         |

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.11.7",
+  "version": "1.11.8",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/docs/guides/en/04-iterate-agent-setup.md
+++ b/docs/guides/en/04-iterate-agent-setup.md
@@ -410,6 +410,32 @@ Logs are saved in JSONL format:
 tmp/logs/agents/climpt/session-2025-12-31T10-00-00-000Z.jsonl
 ```
 
+#### Log Output in Worktree Mode
+
+When running agents in worktree mode (`forceWorktree: true`), logs are always written to the **main repository's** `tmp/logs/` directory, not within the worktree directory.
+
+```
+# Main repository (where you started the agent)
+your-project/
+├── tmp/
+│   └── logs/
+│       └── agents/
+│           └── climpt/
+│               └── session-*.jsonl  ← Logs are written here
+│
+# Worktree (where the agent performs work)
+../worktree/feature-branch/
+├── src/
+└── ...                              ← No logs in worktree
+```
+
+This ensures:
+- **Centralized logging**: All logs are in one location regardless of execution mode
+- **No git pollution**: Worktree directories remain clean for commits
+- **Easy access**: Logs are accessible even after worktree cleanup
+
+> **Note**: The `tmp/` directory is included in `.gitignore`, so logs are never committed.
+
 Viewing logs:
 
 ```bash

--- a/docs/guides/ja/04-iterate-agent-setup.md
+++ b/docs/guides/ja/04-iterate-agent-setup.md
@@ -410,6 +410,32 @@ deno run -A jsr:@aidevtool/climpt/agents/iterator --project 5 --project-owner te
 tmp/logs/agents/climpt/session-2025-12-31T10-00-00-000Z.jsonl
 ```
 
+#### Worktree モードでのログ出力
+
+Worktree モード（`forceWorktree: true`）で agent を実行した場合、ログは常に**メインリポジトリ**の `tmp/logs/` ディレクトリに出力されます。worktree ディレクトリ内には出力されません。
+
+```
+# メインリポジトリ（agent を起動した場所）
+your-project/
+├── tmp/
+│   └── logs/
+│       └── agents/
+│           └── climpt/
+│               └── session-*.jsonl  ← ログはここに出力
+│
+# Worktree（agent が作業を行う場所）
+../worktree/feature-branch/
+├── src/
+└── ...                              ← worktree 内にはログなし
+```
+
+この設計により：
+- **ログの一元管理**: 実行モードに関わらず、すべてのログが同一場所に保存
+- **git 汚染の防止**: worktree ディレクトリがクリーンな状態でコミット可能
+- **アクセスの容易さ**: worktree クリーンアップ後もログにアクセス可能
+
+> **注意**: `tmp/` ディレクトリは `.gitignore` に含まれているため、ログがコミットされることはありません。
+
 ログの確認：
 
 ```bash

--- a/docs/internal/worktree-design.ja.md
+++ b/docs/internal/worktree-design.ja.md
@@ -175,6 +175,48 @@ flowchart TD
 
 ---
 
+## ログ出力
+
+### ログ出力先
+
+Agent のログは、worktree モードに関わらず、常に**メインリポジトリ**の `tmp/logs/` ディレクトリに出力されます。
+
+```
+# メインリポジトリ
+your-project/
+├── tmp/logs/agents/{agent-name}/
+│   └── session-*.jsonl      ← すべてのログはここに出力
+│
+# Worktree（ログなし）
+../worktree/{branch-name}/
+└── (作業ファイルのみ)
+```
+
+### 設計理由
+
+| 課題 | 解決策 |
+|------|--------|
+| 一元管理 | 実行モードに関わらず同一場所にログを保存 |
+| git クリーンネス | worktree はコミット用にクリーン維持 |
+| クリーンアップ後のアクセス | worktree 削除後もログは残存 |
+| 重複防止 | セッションごとに1つのログファイル |
+
+### gitignore 設定
+
+`tmp/` と worktree ディレクトリは git から除外されています：
+
+```gitignore
+# ログディレクトリ
+tmp/
+tmp/*
+
+# Worktree ディレクトリ
+/worktree-*
+/worktree-*/
+```
+
+---
+
 ## 設定例
 
 ```json

--- a/docs/internal/worktree-design.md
+++ b/docs/internal/worktree-design.md
@@ -173,6 +173,48 @@ flowchart TD
 
 ---
 
+## Log Output
+
+### Log Location
+
+Agent logs are always written to the **main repository's** `tmp/logs/` directory, regardless of worktree mode.
+
+```
+# Main repository
+your-project/
+├── tmp/logs/agents/{agent-name}/
+│   └── session-*.jsonl      ← All logs written here
+│
+# Worktree (no logs here)
+../worktree/{branch-name}/
+└── (work files only)
+```
+
+### Rationale
+
+| Concern | Solution |
+|---------|----------|
+| Centralized access | Logs in one location for all execution modes |
+| Git cleanliness | Worktree stays clean for commits |
+| Post-cleanup access | Logs persist after worktree removal |
+| No duplication | Single log per session |
+
+### gitignore Configuration
+
+Both `tmp/` and worktree directories are excluded from git:
+
+```gitignore
+# Log directory
+tmp/
+tmp/*
+
+# Worktree directories
+/worktree-*
+/worktree-*/
+```
+
+---
+
 ## Configuration Example
 
 ```json

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.11.7",
+  "version": "1.11.8",
   "entries": [
     {
       "id": "guides-en-00-1-concepts",
@@ -47,7 +47,7 @@
       "category": "guides",
       "lang": "en",
       "title": "4. Iterate Agent Setup and Execution",
-      "bytes": 13483
+      "bytes": 14416
     },
     {
       "id": "guides-en-05-architecture",
@@ -204,14 +204,14 @@
       "path": "internal/worktree-design.md",
       "category": "internal",
       "title": "Worktree Integration Design Document",
-      "bytes": 6737
+      "bytes": 7593
     },
     {
       "id": "internal-worktree-design.ja",
       "path": "internal/worktree-design.ja.md",
       "category": "internal",
       "title": "Worktree 統合設計書",
-      "bytes": 7297
+      "bytes": 8341
     },
     {
       "id": "mcp-setup",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.11.7";
+export const CLIMPT_VERSION = "1.11.8";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Add step-level model selection design document (agents/docs/design/09_model_selection.md)
- Update README completionType table to current 8 types
- Add model field documentation to agent builder docs

## Version
- 1.11.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)