### PR TITLE
Release 1.11.9

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -253,17 +253,22 @@ Climptは `.agent/climpt/config/` に2つの設定ファイルを使用：
 
 ```bash
 # 全ドキュメントをインストール
-dx jsr:@aidevtool/climpt/docs
+deno run -A jsr:@aidevtool/climpt/docs
 
-# 英語ガイドのみインストール
-dx jsr:@aidevtool/climpt/docs install ./docs --category=guides --lang=en
+# 日本語ガイドのみインストール
+deno run -A jsr:@aidevtool/climpt/docs install ./docs --category=guides --lang=ja
 
 # 1ファイルに結合
-dx jsr:@aidevtool/climpt/docs install ./docs --mode=single
+deno run -A jsr:@aidevtool/climpt/docs install ./docs --mode=single
 
 # 利用可能なドキュメント一覧
-dx jsr:@aidevtool/climpt/docs list
+deno run -A jsr:@aidevtool/climpt/docs list
+
+# 最新バージョンに更新（再ダウンロード）
+deno run -Ar jsr:@aidevtool/climpt/docs install ./docs
 ```
+
+`-r` フラグ（`--reload`）でJSRから最新バージョンを強制的に再ダウンロードします。
 
 📖 [オンラインドキュメント](https://tettuan.github.io/climpt/)
 

--- a/README.md
+++ b/README.md
@@ -253,17 +253,22 @@ Install docs locally as markdown:
 
 ```bash
 # Install all docs
-dx jsr:@aidevtool/climpt/docs
+deno run -A jsr:@aidevtool/climpt/docs
 
 # Install English guides only
-dx jsr:@aidevtool/climpt/docs install ./docs --category=guides --lang=en
+deno run -A jsr:@aidevtool/climpt/docs install ./docs --category=guides --lang=en
 
 # Combine into single file
-dx jsr:@aidevtool/climpt/docs install ./docs --mode=single
+deno run -A jsr:@aidevtool/climpt/docs install ./docs --mode=single
 
 # List available docs
-dx jsr:@aidevtool/climpt/docs list
+deno run -A jsr:@aidevtool/climpt/docs list
+
+# Update to latest version (re-download)
+deno run -Ar jsr:@aidevtool/climpt/docs install ./docs
 ```
+
+The `-r` flag (`--reload`) forces re-download of the latest version from JSR.
 
 📖 [Online Documentation](https://tettuan.github.io/climpt/)
 

--- a/agents/schemas/agent.schema.json
+++ b/agents/schemas/agent.schema.json
@@ -180,6 +180,11 @@
         "askUserAutoResponse": {
           "type": "string",
           "description": "Auto-response message for AskUserQuestion tool. When set, the agent will automatically respond with this message instead of waiting for user input, enabling autonomous execution. Default: 'Use your best judgment to choose the optimal approach. No need to confirm again.'"
+        },
+        "defaultModel": {
+          "type": "string",
+          "enum": ["sonnet", "opus", "haiku"],
+          "description": "Default model for all steps. Resolution order: step.model > behavior.defaultModel > 'opus' (system default). Usually not needed since system default is opus."
         }
       }
     },

--- a/agents/schemas/steps_registry.schema.json
+++ b/agents/schemas/steps_registry.schema.json
@@ -149,6 +149,11 @@
         "description": {
           "type": "string",
           "description": "Optional description of what this step does"
+        },
+        "model": {
+          "type": "string",
+          "enum": ["sonnet", "opus", "haiku"],
+          "description": "Model to use for this step. Resolution order: step.model > behavior.defaultModel > 'opus' (system default). Use haiku for cost optimization on routine steps."
         }
       }
     },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/docs.ts
+++ b/docs.ts
@@ -5,8 +5,9 @@
  *
  * @example CLI
  * ```bash
- * dx jsr:@aidevtool/climpt/docs
- * dx jsr:@aidevtool/climpt/docs install ./docs --lang=ja
+ * deno run -A jsr:@aidevtool/climpt/docs
+ * deno run -A jsr:@aidevtool/climpt/docs install ./docs --lang=ja
+ * deno run -Ar jsr:@aidevtool/climpt/docs install ./docs  # Update to latest
  * ```
  *
  * @example API
@@ -20,3 +21,8 @@
 
 export { install, list } from "./src/docs/mod.ts";
 export type { Entry, Options, Result } from "./src/docs/types.ts";
+
+if (import.meta.main) {
+  const { main } = await import("./src/docs/cli.ts");
+  await main();
+}

--- a/src/docs/cli.ts
+++ b/src/docs/cli.ts
@@ -9,12 +9,17 @@
  *
  * @example Install all docs
  * ```bash
- * dx jsr:@aidevtool/climpt/docs/cli
+ * deno run -A jsr:@aidevtool/climpt/docs
  * ```
  *
  * @example Install Japanese guides only
  * ```bash
- * dx jsr:@aidevtool/climpt/docs/cli install ./docs --lang=ja --category=guides
+ * deno run -A jsr:@aidevtool/climpt/docs install ./docs --lang=ja --category=guides
+ * ```
+ *
+ * @example Update to latest version
+ * ```bash
+ * deno run -Ar jsr:@aidevtool/climpt/docs install ./docs
  * ```
  */
 
@@ -22,7 +27,7 @@ import { parseArgs } from "@std/cli/parse-args";
 import { install, list } from "./mod.ts";
 
 const HELP = `
-Usage: dx jsr:@aidevtool/climpt/docs [command] [options]
+Usage: deno run -A jsr:@aidevtool/climpt/docs [command] [options]
 
 Commands:
   install [dir]   Install docs (default: ./climpt-docs)
@@ -34,9 +39,12 @@ Options:
   --mode=MODE     Output: preserve | flatten | single
   --version=VER   Specific version (default: latest)
   -h, --help      Show help
+
+Update to latest:
+  deno run -Ar jsr:@aidevtool/climpt/docs install ./docs
 `;
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const args = parseArgs(Deno.args, {
     boolean: ["help"],
     string: ["category", "lang", "mode", "version"],

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.11.8";
+export const CLIMPT_VERSION = "1.11.9";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
Release version 1.11.9 to production

## Changes in this release
- Fix docs CLI entry point for direct execution via JSR
- Add docs update instructions to README
- Add model selection schema fields (defaultModel, step.model)