### PR TITLE
Release 1.11.18: update all dependencies to latest

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -78,16 +78,16 @@
     "verify-docs": "deno run --allow-read --allow-run .claude/skills/docs-consistency/scripts/verify-docs.ts"
   },
   "imports": {
-    "@aidevtool/frontmatter-to-schema": "jsr:@aidevtool/frontmatter-to-schema@^1.7.1",
-    "@anthropic-ai/claude-agent-sdk": "npm:@anthropic-ai/claude-agent-sdk@^0.2.37",
-    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@^2.1.37",
-    "@modelcontextprotocol/sdk/server": "npm:@modelcontextprotocol/sdk@0.7.0/server/index.js",
-    "@modelcontextprotocol/sdk/server/stdio": "npm:@modelcontextprotocol/sdk@0.7.0/server/stdio.js",
-    "@modelcontextprotocol/sdk/types": "npm:@modelcontextprotocol/sdk@0.7.0/types.js",
+    "@aidevtool/frontmatter-to-schema": "jsr:@aidevtool/frontmatter-to-schema@^1.7.3",
+    "@anthropic-ai/claude-agent-sdk": "npm:@anthropic-ai/claude-agent-sdk@^0.2.39",
+    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@^2.1.39",
+    "@modelcontextprotocol/sdk/server": "npm:@modelcontextprotocol/sdk@1.26.0/server/index.js",
+    "@modelcontextprotocol/sdk/server/stdio": "npm:@modelcontextprotocol/sdk@1.26.0/server/stdio.js",
+    "@modelcontextprotocol/sdk/types": "npm:@modelcontextprotocol/sdk@1.26.0/types.js",
     "@std/assert": "jsr:@std/assert@^1",
-    "@std/cli": "jsr:@std/cli@^1.0.23",
-    "@std/fs": "jsr:@std/fs@^1.0.8",
-    "@std/path": "jsr:@std/path@^1.1.3"
+    "@std/cli": "jsr:@std/cli@^1.0.27",
+    "@std/fs": "jsr:@std/fs@^1.0.22",
+    "@std/path": "jsr:@std/path@^1.1.4"
   },
   "compilerOptions": {
     "lib": ["deno.ns", "dom", "es2022"],

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.11.17",
+  "version": "1.11.18",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/plugins/climpt-agent/skills/delegate-climpt-agent/scripts/climpt-agent/options-prompt.ts
+++ b/plugins/climpt-agent/skills/delegate-climpt-agent/scripts/climpt-agent/options-prompt.ts
@@ -14,7 +14,7 @@
  *   - Skip: Options with false value
  */
 
-import { query } from "npm:@anthropic-ai/claude-agent-sdk@^0.2.37";
+import { query } from "npm:@anthropic-ai/claude-agent-sdk@^0.2.39";
 
 import type { CommandWithUV, PromptContext, ResolvedOptions } from "./types.ts";
 import type { Logger } from "./logger.ts";

--- a/plugins/climpt-agent/skills/delegate-climpt-agent/scripts/climpt-agent/sub-agent.ts
+++ b/plugins/climpt-agent/skills/delegate-climpt-agent/scripts/climpt-agent/sub-agent.ts
@@ -4,11 +4,11 @@
  * @module climpt-plugins/skills/delegate-climpt-agent/scripts/sub-agent
  */
 
-import { query } from "npm:@anthropic-ai/claude-agent-sdk@^0.2.37";
+import { query } from "npm:@anthropic-ai/claude-agent-sdk@^0.2.39";
 import type {
   Options,
   SDKMessage,
-} from "npm:@anthropic-ai/claude-agent-sdk@^0.2.37";
+} from "npm:@anthropic-ai/claude-agent-sdk@^0.2.39";
 
 import type { Logger } from "./logger.ts";
 import { resolvePluginPathsSafe } from "../../../../lib/plugin-resolver.ts";

--- a/plugins/climpt-agent/skills/delegate-climpt-agent/scripts/climpt-agent/summary.ts
+++ b/plugins/climpt-agent/skills/delegate-climpt-agent/scripts/climpt-agent/summary.ts
@@ -3,7 +3,7 @@
  * @module climpt-plugins/skills/delegate-climpt-agent/scripts/summary
  */
 
-import { query } from "npm:@anthropic-ai/claude-agent-sdk@^0.2.37";
+import { query } from "npm:@anthropic-ai/claude-agent-sdk@^0.2.39";
 
 /**
  * Read JSONL log and extract assistant messages

--- a/scripts/mcp/simple-mcp-test.ts
+++ b/scripts/mcp/simple-mcp-test.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-net --allow-env
 // deno-lint-ignore-file no-console prefer-ascii explicit-function-return-type
 
-import { Server } from "npm:@modelcontextprotocol/sdk@0.7.0/server/index.js";
-import { StdioServerTransport } from "npm:@modelcontextprotocol/sdk@0.7.0/server/stdio.js";
+import { Server } from "npm:@modelcontextprotocol/sdk@1.26.0/server/index.js";
+import { StdioServerTransport } from "npm:@modelcontextprotocol/sdk@1.26.0/server/stdio.js";
 import {
   type CallToolRequest,
   CallToolRequestSchema,
   type ListToolsRequest,
   ListToolsRequestSchema,
-} from "npm:@modelcontextprotocol/sdk@0.7.0/types.js";
+} from "npm:@modelcontextprotocol/sdk@1.26.0/types.js";
 
 console.error("🧪 Simple MCP Test Server starting...");
 

--- a/scripts/mcp/test-mcp.ts
+++ b/scripts/mcp/test-mcp.ts
@@ -1,13 +1,13 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-net --allow-env
 // deno-lint-ignore-file no-console prefer-ascii explicit-function-return-type
 
-import { Client } from "npm:@modelcontextprotocol/sdk@0.7.0/client/index.js";
-import { StdioClientTransport } from "npm:@modelcontextprotocol/sdk@0.7.0/client/stdio.js";
+import { Client } from "npm:@modelcontextprotocol/sdk@1.26.0/client/index.js";
+import { StdioClientTransport } from "npm:@modelcontextprotocol/sdk@1.26.0/client/stdio.js";
 import {
   GetPromptResultSchema,
   ListPromptsResultSchema,
   ListToolsResultSchema,
-} from "npm:@modelcontextprotocol/sdk@0.7.0/types.js";
+} from "npm:@modelcontextprotocol/sdk@1.26.0/types.js";
 
 async function testMCPServer() {
   console.log("Starting MCP Server test...\n");

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.11.17";
+export const CLIMPT_VERSION = "1.11.18";
 
 /**
  * Version of the breakdown package to use.

--- a/src/version.ts
+++ b/src/version.ts
@@ -47,4 +47,4 @@ export const BREAKDOWN_VERSION = "1.8.2";
  *
  * @constant {string}
  */
-export const FRONTMATTER_TO_SCHEMA_VERSION = "1.7.1";
+export const FRONTMATTER_TO_SCHEMA_VERSION = "1.7.3";


### PR DESCRIPTION
## Summary
- Update @modelcontextprotocol/sdk: 0.7.0 → 1.26.0
- Update @anthropic-ai/claude-agent-sdk: ^0.2.37 → ^0.2.39
- Update @anthropic-ai/claude-code: ^2.1.37 → ^2.1.39
- Update @aidevtool/frontmatter-to-schema: ^1.7.1 → ^1.7.3
- Update @std/cli: ^1.0.23 → ^1.0.27
- Update @std/fs: ^1.0.8 → ^1.0.22
- Update @std/path: ^1.1.3 → ^1.1.4

## Version
- 1.11.18