### PR TITLE
Release 1.11.19: fix ToolPolicy error message contradiction

### DIFF
--- a/agents/common/tool-policy.ts
+++ b/agents/common/tool-policy.ts
@@ -38,7 +38,7 @@ export const BOUNDARY_TOOLS = [
  * boundary actions from being executed directly via bash in ANY step kind
  * (including closure steps). The Boundary Hook is the only execution path.
  *
- * Classification criteria — blocked vs allowed:
+ * Classification criteria --blocked vs allowed:
  *   Blocked: Termination actions (close, merge, delete) and state mutations
  *            that are irreversible or require structured decision-making.
  *            These MUST go through the Boundary Hook.
@@ -48,7 +48,7 @@ export const BOUNDARY_TOOLS = [
  *            layer, not a closure/termination action.
  */
 export const BOUNDARY_BASH_PATTERNS = [
-  // Termination actions — close/delete/merge end a workflow
+  // Termination actions --close/delete/merge end a workflow
   /\bgh\s+issue\s+close\b/,
   /\bgh\s+issue\s+delete\b/,
   /\bgh\s+issue\s+transfer\b/,
@@ -58,7 +58,7 @@ export const BOUNDARY_BASH_PATTERNS = [
   /\bgh\s+pr\s+close\b/,
   /\bgh\s+pr\s+merge\b/,
   /\bgh\s+pr\s+ready\b/,
-  // Release operations — public-facing and irreversible
+  // Release operations --public-facing and irreversible
   /\bgh\s+release\s+create\b/,
   /\bgh\s+release\s+edit\b/,
   // GitHub API - block all direct API calls (can bypass other restrictions)

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.11.18",
+  "version": "1.11.19",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.11.18";
+export const CLIMPT_VERSION = "1.11.19";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- fix: Resolve ToolPolicy error message contradiction in closure step (C1/C2)
- docs: Clarify Boundary Hook execution flow and bash blocking in step flow design (D1/D2/D3)

## Changes
- **C1**: `isBashCommandAllowed()` now branches on stepKind — closure gets "cannot execute directly, use closing intent" instead of contradictory message
- **C1**: `isToolAllowed()` unified message — "handled by Boundary Hook" replaces "only permitted in closure"
- **C2**: Added classification criteria comment to `BOUNDARY_BASH_PATTERNS` (blocked vs allowed)
- **D1**: Updated §7.2 Mermaid diagram — `github-actions` → `boundary-tools` with bash block note
- **D2**: Added Boundary Hook execution flow to §7.1
- **D3**: Added `blockBoundaryBash: true` design rationale and 2-layer safety boundary to §7.2

## Version
- 1.11.19