### PR TITLE
Release 1.11.22: fix V1-V2 completion handler gap

### DIFF
--- a/agents/completion/external-state-adapter.ts
+++ b/agents/completion/external-state-adapter.ts
@@ -1,0 +1,191 @@
+/**
+ * External State Completion Adapter
+ *
+ * Bridges ContractCompletionHandler (V2) to CompletionHandler (V1) interface.
+ * Enables the Runner to use V2 IssueCompletionHandler without Runner changes.
+ *
+ * Resolves:
+ * - Gap 2: Interface mismatch (ContractCompletionHandler -> CompletionHandler)
+ * - Gap 3: isComplete() logic (refreshState -> check bridge)
+ * - Gap 4: onBoundaryHook() (GitHub label/close operations)
+ * - Gap 5: Prompt construction (PromptResolver integration)
+ */
+
+import type { PromptResolverAdapter as PromptResolver } from "../prompts/resolver-adapter.ts";
+import {
+  BaseCompletionHandler,
+  type CompletionCriteria,
+  type IterationSummary,
+} from "./types.ts";
+import type { IssueCompletionHandler } from "./issue.ts";
+import { STEP_PHASE } from "../shared/step-phases.ts";
+
+/**
+ * Configuration for the adapter, extracted from AgentDefinition and args.
+ */
+export interface ExternalStateAdapterConfig {
+  /** Issue number being tracked */
+  issueNumber: number;
+  /** Repository in "owner/repo" format */
+  repo?: string;
+  /** GitHub label configuration from agent definition */
+  github?: {
+    labels?: {
+      completion?: { add?: string[]; remove?: string[] };
+    };
+    defaultClosureAction?: string;
+  };
+}
+
+/**
+ * Adapter that wraps IssueCompletionHandler (ContractCompletionHandler)
+ * and exposes CompletionHandler interface expected by AgentRunner.
+ *
+ * Method mapping:
+ * - buildInitialPrompt() -> PromptResolver.resolve("initial_issue") || handler.buildPrompt(INITIAL, 1)
+ * - buildContinuationPrompt() -> PromptResolver.resolve("continuation_issue") || handler.buildPrompt(CONTINUATION, n)
+ * - buildCompletionCriteria() -> handler.getCompletionCriteria() with field name mapping
+ * - isComplete() -> handler.refreshState() + handler.check()
+ * - getCompletionDescription() -> derived from check result
+ * - onBoundaryHook() -> gh issue edit (labels) + gh issue close
+ * - setCurrentSummary() -> stored for future use
+ */
+export class ExternalStateCompletionAdapter extends BaseCompletionHandler {
+  readonly type = "externalState" as const;
+  private promptResolver?: PromptResolver;
+  private currentSummary?: IterationSummary;
+
+  constructor(
+    private readonly handler: IssueCompletionHandler,
+    private readonly config: ExternalStateAdapterConfig,
+  ) {
+    super();
+  }
+
+  /**
+   * Set prompt resolver for externalized prompts.
+   */
+  setPromptResolver(resolver: PromptResolver): void {
+    this.promptResolver = resolver;
+  }
+
+  /**
+   * Set current iteration summary (called by runner before isComplete).
+   */
+  setCurrentSummary(summary: IterationSummary): void {
+    this.currentSummary = summary;
+  }
+
+  async buildInitialPrompt(): Promise<string> {
+    if (this.promptResolver) {
+      return await this.promptResolver.resolve("initial_issue", {
+        "uv-issue_number": String(this.config.issueNumber),
+        "uv-repository": this.config.repo ?? "",
+      });
+    }
+    return this.handler.buildPrompt(STEP_PHASE.INITIAL, 1);
+  }
+
+  async buildContinuationPrompt(
+    completedIterations: number,
+    previousSummary?: IterationSummary,
+  ): Promise<string> {
+    const summaryText = previousSummary
+      ? this.formatIterationSummary(previousSummary)
+      : "";
+
+    if (this.promptResolver) {
+      return await this.promptResolver.resolve("continuation_issue", {
+        "uv-issue_number": String(this.config.issueNumber),
+        "uv-iteration": String(completedIterations),
+        "uv-previous_summary": summaryText,
+      });
+    }
+
+    return this.handler.buildPrompt(
+      STEP_PHASE.CONTINUATION,
+      completedIterations + 1,
+    );
+  }
+
+  buildCompletionCriteria(): CompletionCriteria {
+    const criteria = this.handler.getCompletionCriteria();
+    return {
+      short: criteria.summary,
+      detailed: criteria.detailed,
+    };
+  }
+
+  /**
+   * Check completion by refreshing external state then checking.
+   * Bridges V2's separate refreshState()/check() to V1's single isComplete().
+   */
+  async isComplete(): Promise<boolean> {
+    await this.handler.refreshState();
+    const result = this.handler.check({ iteration: 1 });
+    return result.complete;
+  }
+
+  getCompletionDescription(): Promise<string> {
+    const result = this.handler.check({ iteration: 1 });
+    if (result.complete) {
+      return Promise.resolve(
+        result.reason ?? `Issue #${this.config.issueNumber} is closed`,
+      );
+    }
+    return Promise.resolve(
+      `Waiting for Issue #${this.config.issueNumber} to close`,
+    );
+  }
+
+  /**
+   * Handle boundary hook for closure steps.
+   * Performs GitHub operations: update labels and optionally close issue.
+   */
+  async onBoundaryHook(_payload: {
+    stepId: string;
+    stepKind: "closure";
+    structuredOutput?: Record<string, unknown>;
+  }): Promise<void> {
+    const { issueNumber, repo, github } = this.config;
+
+    // Update labels if configured
+    if (github?.labels?.completion) {
+      const { add, remove } = github.labels.completion;
+      const labelArgs: string[] = [];
+      if (add?.length) labelArgs.push("--add-label", add.join(","));
+      if (remove?.length) labelArgs.push("--remove-label", remove.join(","));
+
+      if (labelArgs.length > 0) {
+        const args = ["issue", "edit", String(issueNumber), ...labelArgs];
+        if (repo) args.push("--repo", repo);
+        try {
+          const cmd = new Deno.Command("gh", {
+            args,
+            stdout: "piped",
+            stderr: "piped",
+          });
+          await cmd.output();
+        } catch {
+          // Non-fatal: label update failure should not stop the agent
+        }
+      }
+    }
+
+    // Close issue unless defaultClosureAction is "label-only"
+    if (github?.defaultClosureAction !== "label-only") {
+      const args = ["issue", "close", String(issueNumber)];
+      if (repo) args.push("--repo", repo);
+      try {
+        const cmd = new Deno.Command("gh", {
+          args,
+          stdout: "piped",
+          stderr: "piped",
+        });
+        await cmd.output();
+      } catch {
+        // Non-fatal: issue close failure should not stop the agent
+      }
+    }
+  }
+}

--- a/agents/completion/mod.ts
+++ b/agents/completion/mod.ts
@@ -33,13 +33,7 @@ export type {
 } from "./types.ts";
 
 // Factory functions
-export {
-  type CompletionHandlerOptions,
-  createCompletionHandler,
-  createRegistryCompletionHandler,
-  getRegisteredHandler,
-  registerCompletionHandler,
-} from "./factory.ts";
+export { createRegistryCompletionHandler } from "./factory.ts";
 
 // External State Checker
 export {
@@ -51,6 +45,12 @@ export {
 
 // Issue completion handler (contract-compliant)
 export { IssueCompletionHandler, type IssueContractConfig } from "./issue.ts";
+
+// External state adapter (bridges ContractCompletionHandler -> CompletionHandler)
+export {
+  type ExternalStateAdapterConfig,
+  ExternalStateCompletionAdapter,
+} from "./external-state-adapter.ts";
 
 // iterationBudget (was: iterate) - Complete after N iterations
 export { IterateCompletionHandler } from "./iterate.ts";

--- a/agents/mod.ts
+++ b/agents/mod.ts
@@ -92,14 +92,10 @@ export {
   BaseCompletionHandler,
   type CompletionCriteria,
   type CompletionHandler,
-  type CompletionHandlerOptions,
-  createCompletionHandler,
   createRegistryCompletionHandler,
-  getRegisteredHandler,
   IssueCompletionHandler,
   IterateCompletionHandler,
   ManualCompletionHandler,
-  registerCompletionHandler,
 } from "./completion/mod.ts";
 
 // === Init and Runtime ===

--- a/agents/runner/mod.ts
+++ b/agents/runner/mod.ts
@@ -23,7 +23,6 @@ export type { FormatValidationResult } from "../loop/mod.ts";
 
 // Completion Layer
 export {
-  createCompletionHandler,
   GitHubStateChecker,
   IssueCompletionHandler,
   MockStateChecker,

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.11.21",
+  "version": "1.11.22",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/examples/27v_verify_factory_completionpath/run.sh
+++ b/examples/27v_verify_factory_completionpath/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+source "${REPO_ROOT}/examples/common_functions.sh"
+
+main() {
+  info "=== Verify Factory Completion Paths ==="
+
+  check_deno
+
+  info "Running factory path validation for all completion types..."
+
+  local output
+  output="$(cd "${REPO_ROOT}" && deno run --allow-read --allow-env "${SCRIPT_DIR}/scripts/validate-factory-path.ts" 2>&1)" || {
+    error "Factory path validation failed"
+    echo "${output}"
+    return 1
+  }
+
+  echo "${output}"
+
+  # Check for any FAIL lines
+  if echo "${output}" | grep -q "FAIL:"; then
+    error "Validation reported failures"
+    return 1
+  fi
+
+  # Verify summary exists
+  if ! echo "${output}" | grep -q "Summary:"; then
+    error "Missing Summary marker"
+    return 1
+  fi
+
+  success "PASS: factory completion path verification passed"
+}
+
+main "$@"

--- a/examples/27v_verify_factory_completionpath/scripts/validate-factory-path.ts
+++ b/examples/27v_verify_factory_completionpath/scripts/validate-factory-path.ts
@@ -1,0 +1,207 @@
+/**
+ * Verify factory completion handler creation paths.
+ *
+ * Tests that createRegistryCompletionHandler can produce a working
+ * CompletionHandler for each registered completionType without LLM calls.
+ *
+ * This catches regressions where a handler registration becomes a
+ * throw-only stub (as happened with externalState during V2 migration).
+ */
+
+import { resolve } from "@std/path";
+import type { AgentDefinition } from "../../../agents/src_common/types.ts";
+import { createRegistryCompletionHandler } from "../../../agents/completion/factory.ts";
+import { ExternalStateCompletionAdapter } from "../../../agents/completion/external-state-adapter.ts";
+
+// deno-lint-ignore no-console
+const log = console.log;
+// deno-lint-ignore no-console
+const logErr = console.error;
+
+const repoRoot = resolve(import.meta.dirname ?? ".", "../../../");
+
+interface TestCase {
+  name: string;
+  completionType: string;
+  completionConfig: Record<string, unknown>;
+  args: Record<string, unknown>;
+  expectedType: string;
+  expectedClass?: string;
+}
+
+const testCases: TestCase[] = [
+  {
+    name: "externalState with --issue",
+    completionType: "externalState",
+    completionConfig: { maxIterations: 10 },
+    args: { issue: 123, repository: "owner/repo" },
+    expectedType: "externalState",
+    expectedClass: "ExternalStateCompletionAdapter",
+  },
+  {
+    name: "iterationBudget",
+    completionType: "iterationBudget",
+    completionConfig: { maxIterations: 5 },
+    args: {},
+    expectedType: "iterationBudget",
+  },
+  {
+    name: "keywordSignal",
+    completionType: "keywordSignal",
+    completionConfig: { completionKeyword: "DONE" },
+    args: {},
+    expectedType: "keywordSignal",
+  },
+  {
+    name: "checkBudget",
+    completionType: "checkBudget",
+    completionConfig: { maxChecks: 10 },
+    args: {},
+    expectedType: "checkBudget",
+  },
+  {
+    name: "structuredSignal",
+    completionType: "structuredSignal",
+    completionConfig: { signalType: "test-signal" },
+    args: {},
+    expectedType: "structuredSignal",
+  },
+];
+
+const errorCases: {
+  name: string;
+  completionType: string;
+  args: Record<string, unknown>;
+  completionConfig: Record<string, unknown>;
+  expectedError: string;
+}[] = [
+  {
+    name: "externalState without --issue",
+    completionType: "externalState",
+    completionConfig: { maxIterations: 10 },
+    args: {},
+    expectedError: "requires --issue",
+  },
+];
+
+function createTestDefinition(
+  completionType: string,
+  completionConfig: Record<string, unknown>,
+): AgentDefinition {
+  return {
+    version: "1.0.0",
+    name: "test-agent",
+    displayName: "Test Agent",
+    description: "Factory path verification test agent",
+    behavior: {
+      systemPromptPath: "prompts/system.md",
+      completionType:
+        completionType as AgentDefinition["behavior"]["completionType"],
+      completionConfig,
+      allowedTools: ["Read"],
+      permissionMode: "default",
+    },
+    parameters: {},
+    prompts: { registry: "steps_registry.json", fallbackDir: "prompts/" },
+    github: { enabled: true, labels: {}, defaultClosureAction: "label-only" },
+    logging: { directory: "/tmp/claude/test-logs", format: "jsonl" },
+  } as AgentDefinition;
+}
+
+let passed = 0;
+let failed = 0;
+
+log("=== Verify Factory Completion Paths ===\n");
+
+// Test successful handler creation
+log("--- Handler Creation Tests ---");
+for (const tc of testCases) {
+  try {
+    const def = createTestDefinition(tc.completionType, tc.completionConfig);
+    const agentDir = resolve(repoRoot, ".agent/iterator");
+    // deno-lint-ignore no-await-in-loop
+    const handler = await createRegistryCompletionHandler(
+      def,
+      tc.args,
+      agentDir,
+    );
+
+    if (handler.type !== tc.expectedType) {
+      logErr(
+        `FAIL: ${tc.name} - expected type "${tc.expectedType}", got "${handler.type}"`,
+      );
+      failed++;
+      continue;
+    }
+
+    if (tc.expectedClass === "ExternalStateCompletionAdapter") {
+      if (!(handler instanceof ExternalStateCompletionAdapter)) {
+        logErr(
+          `FAIL: ${tc.name} - expected ExternalStateCompletionAdapter instance`,
+        );
+        failed++;
+        continue;
+      }
+    }
+
+    // Verify CompletionHandler interface methods exist
+    const methods = [
+      "buildInitialPrompt",
+      "buildContinuationPrompt",
+      "buildCompletionCriteria",
+      "isComplete",
+      "getCompletionDescription",
+    ];
+    const handlerRecord = handler as unknown as Record<string, unknown>;
+    const missing = methods.filter((m) =>
+      typeof handlerRecord[m] !== "function"
+    );
+    if (missing.length > 0) {
+      logErr(
+        `FAIL: ${tc.name} - missing CompletionHandler methods: ${
+          missing.join(", ")
+        }`,
+      );
+      failed++;
+      continue;
+    }
+
+    log(
+      `  PASS: ${tc.name} -> type="${handler.type}", class=${handler.constructor.name}`,
+    );
+    passed++;
+  } catch (error) {
+    logErr(`FAIL: ${tc.name} - ${(error as Error).message}`);
+    failed++;
+  }
+}
+
+// Test expected error cases
+log("\n--- Error Handling Tests ---");
+for (const tc of errorCases) {
+  try {
+    const def = createTestDefinition(tc.completionType, tc.completionConfig);
+    const agentDir = resolve(repoRoot, ".agent/iterator");
+    // deno-lint-ignore no-await-in-loop
+    await createRegistryCompletionHandler(def, tc.args, agentDir);
+    logErr(`FAIL: ${tc.name} - expected error but succeeded`);
+    failed++;
+  } catch (error) {
+    const msg = (error as Error).message;
+    if (msg.includes(tc.expectedError)) {
+      log(`  PASS: ${tc.name} -> throws "${tc.expectedError}"`);
+      passed++;
+    } else {
+      logErr(
+        `FAIL: ${tc.name} - expected "${tc.expectedError}" in error, got "${msg}"`,
+      );
+      failed++;
+    }
+  }
+}
+
+// Summary
+log(`\nSummary: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) {
+  Deno.exit(1);
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.11.21";
+export const CLIMPT_VERSION = "1.11.22";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Fix externalState completion type broken by V2 architecture migration
- Add ExternalStateCompletionAdapter bridging ContractCompletionHandler -> CompletionHandler
- Fix factory.ts externalState registration (was throw-only stub)
- Restore externalState case in composite.ts
- Add 12 regression tests + factory path verification example (27v)
- Remove dead code: createCompletionHandler and related symbols

## Version
- 1.11.22

## CI
- 663 tests passed, 218 type check, 218 lint, JSR OK