### PR TITLE
Release 1.12.2

### DIFF
--- a/agents/scripts/run-agent.ts
+++ b/agents/scripts/run-agent.ts
@@ -7,12 +7,12 @@
  *
  * @example Run iterator agent
  * ```bash
- * deno run -A agents/scripts/run-agent.ts --agent iterator --issue 123
+ * deno run --allow-all agents/scripts/run-agent.ts --agent iterator --issue 123
  * ```
  *
  * @example Run reviewer agent
  * ```bash
- * deno run -A agents/scripts/run-agent.ts --agent reviewer --issue 123
+ * deno run --allow-all agents/scripts/run-agent.ts --agent reviewer --issue 123
  * ```
  */
 
@@ -32,15 +32,20 @@ import type {
 } from "../common/types.ts";
 import type { FinalizeConfig } from "../src_common/types.ts";
 
+const SCRIPT = "agents/scripts/run-agent.ts";
+const RUN = `deno run --allow-all ${SCRIPT}`;
+const RUN_RW = `deno run --allow-read --allow-write ${SCRIPT}`;
+const RUN_RO = `deno run --allow-read ${SCRIPT}`;
+
 function printHelp(): void {
   // deno-lint-ignore no-console
   console.log(`
 Unified Agent Runner
 
 Usage:
-  deno task agent --agent <name> [options]
-  deno task agent --init --agent <name>
-  deno task agent --list
+  ${RUN} --agent <name> [options]
+  ${RUN_RW} --init --agent <name>
+  ${RUN_RO} --list
 
 Required:
   --agent, -a <name>     Agent name (iterator, reviewer, etc.)
@@ -49,21 +54,6 @@ Options:
   --help, -h             Show this help message
   --init                 Initialize new agent with basic template
   --list                 List available agents
-
-Agent Initialization:
-  --init creates a minimal agent template in .agent/<name>/
-
-  For advanced scaffolding with step flow, use the scaffolder skill:
-    /agent-scaffolder (in Claude Code)
-
-  Note: The scaffolder skill requires the plugin-dev plugin.
-  Install: https://github.com/anthropics/claude-code-plugin-dev
-
-  Scaffolder features:
-    - Interactive completionType selection
-    - Step flow configuration (stepMachine)
-    - Schema generation for structured outputs
-    - C3L prompt structure setup
 
 Common Options:
   --issue, -i <number>   GitHub Issue number
@@ -81,14 +71,9 @@ Finalize Options:
   --pr-target <branch>   Target branch for PR (default: base branch)
 
 Examples:
-  # Initialize new agent
-  deno task agent --init --agent my-agent
-
-  # Work on a GitHub Issue
-  deno task agent --agent iterator --issue 123
-
-  # Review an issue
-  deno task agent --agent reviewer --issue 123
+  ${RUN_RW} --init --agent my-agent
+  ${RUN} --agent iterator --issue 123
+  ${RUN} --agent reviewer --issue 123
 
 Documentation:
   Quick Start:      agents/docs/builder/01_quickstart.md

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,9 @@ Examples:
   # Generate from standard input
   echo "error log" | climpt-diagnose trace stack -e=test -o=./output
 
+Agent Runner:
+  deno run --allow-read agents/scripts/run-agent.ts --help
+
 MCP Server:
   Climpt supports Model Context Protocol (MCP) for AI assistant integration.
   For details: https://jsr.io/@aidevtool/climpt

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.12.1";
+export const CLIMPT_VERSION = "1.12.2";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Help message improvements: direct script execution instead of deno task
- Agent Runner reference added to root `climpt --help`
- Version bump to 1.12.2

## Test plan
- [x] CI passed on release branch
- [x] PR #391 merged to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)