### PR TITLE
Release 1.12.4

### DIFF
--- a/agents/completion/check-budget.ts
+++ b/agents/completion/check-budget.ts
@@ -44,7 +44,7 @@ export class CheckBudgetCompletionHandler extends BaseCompletionHandler {
 
   async buildInitialPrompt(): Promise<string> {
     if (this.promptResolver) {
-      return await this.promptResolver.resolve("initial_check_budget", {
+      return await this.promptResolver.resolve("initial.checkBudget", {
         "uv-max_checks": String(this.maxChecks),
       });
     }
@@ -85,7 +85,7 @@ Work efficiently to complete your monitoring goal within the check budget.
       const summaryText = previousSummary
         ? this.formatIterationSummary(previousSummary)
         : "";
-      return await this.promptResolver.resolve("continuation_check_budget", {
+      return await this.promptResolver.resolve("continuation.checkBudget", {
         "uv-check_count": String(this.checkCount),
         "uv-max_checks": String(this.maxChecks),
         "uv-remaining": String(remaining),

--- a/agents/completion/composite.ts
+++ b/agents/completion/composite.ts
@@ -153,7 +153,7 @@ export class CompositeCompletionHandler extends BaseCompletionHandler {
     }
 
     if (this.promptResolver) {
-      return await this.promptResolver.resolve("initial_composite", {
+      return await this.promptResolver.resolve("initial.composite", {
         "uv-operator": this.operator,
         "uv-conditions_count": String(this.conditions.length),
       });

--- a/agents/completion/external-state-adapter.ts
+++ b/agents/completion/external-state-adapter.ts
@@ -42,8 +42,8 @@ export interface ExternalStateAdapterConfig {
  * and exposes CompletionHandler interface expected by AgentRunner.
  *
  * Method mapping:
- * - buildInitialPrompt() -> PromptResolver.resolve("initial_issue") || handler.buildPrompt(INITIAL, 1)
- * - buildContinuationPrompt() -> PromptResolver.resolve("continuation_issue") || handler.buildPrompt(CONTINUATION, n)
+ * - buildInitialPrompt() -> PromptResolver.resolve("initial.externalState") || handler.buildPrompt(INITIAL, 1)
+ * - buildContinuationPrompt() -> PromptResolver.resolve("continuation.externalState") || handler.buildPrompt(CONTINUATION, n)
  * - buildCompletionCriteria() -> handler.getCompletionCriteria() with field name mapping
  * - isComplete() -> handler.refreshState() + handler.check()
  * - getCompletionDescription() -> derived from check result
@@ -78,7 +78,7 @@ export class ExternalStateCompletionAdapter extends BaseCompletionHandler {
 
   async buildInitialPrompt(): Promise<string> {
     if (this.promptResolver) {
-      return await this.promptResolver.resolve("initial_issue", {
+      return await this.promptResolver.resolve("initial.externalState", {
         "uv-issue_number": String(this.config.issueNumber),
         "uv-repository": this.config.repo ?? "",
       });
@@ -95,7 +95,7 @@ export class ExternalStateCompletionAdapter extends BaseCompletionHandler {
       : "";
 
     if (this.promptResolver) {
-      return await this.promptResolver.resolve("continuation_issue", {
+      return await this.promptResolver.resolve("continuation.externalState", {
         "uv-issue_number": String(this.config.issueNumber),
         "uv-iteration": String(completedIterations),
         "uv-previous_summary": summaryText,

--- a/agents/completion/iterate.ts
+++ b/agents/completion/iterate.ts
@@ -34,7 +34,7 @@ export class IterateCompletionHandler extends BaseCompletionHandler {
 
   async buildInitialPrompt(): Promise<string> {
     if (this.promptResolver) {
-      return await this.promptResolver.resolve("initial_iterate", {
+      return await this.promptResolver.resolve("initial.iterate", {
         "uv-max_iterations": String(this.maxIterations),
       });
     }
@@ -74,7 +74,7 @@ Work efficiently to complete your goal within the iteration limit.
       const summaryText = previousSummary
         ? this.formatIterationSummary(previousSummary)
         : "";
-      return await this.promptResolver.resolve("continuation_iterate", {
+      return await this.promptResolver.resolve("continuation.iterate", {
         "uv-iteration": String(completedIterations),
         "uv-max_iterations": String(this.maxIterations),
         "uv-remaining": String(remaining),

--- a/agents/completion/manual.ts
+++ b/agents/completion/manual.ts
@@ -29,7 +29,7 @@ export class ManualCompletionHandler extends BaseCompletionHandler {
 
   async buildInitialPrompt(): Promise<string> {
     if (this.promptResolver) {
-      return await this.promptResolver.resolve("initial_manual", {
+      return await this.promptResolver.resolve("initial.manual", {
         "uv-completion_keyword": this.completionKeyword,
       });
     }
@@ -61,7 +61,7 @@ When ready, output exactly: ${this.completionKeyword}
       const summaryText = previousSummary
         ? this.formatIterationSummary(previousSummary)
         : "";
-      return await this.promptResolver.resolve("continuation_manual", {
+      return await this.promptResolver.resolve("continuation.manual", {
         "uv-iteration": String(completedIterations),
         "uv-completion_keyword": this.completionKeyword,
         "uv-previous_summary": summaryText,

--- a/agents/completion/step-machine.ts
+++ b/agents/completion/step-machine.ts
@@ -245,15 +245,16 @@ export class StepMachineCompletionHandler extends BaseCompletionHandler {
     const stepDef = this.getStepDefinition(this.state.currentStepId);
 
     if (this.promptResolver && stepDef) {
-      // Build UV variables from step definition
       const uvVars: Record<string, string> = {
         "uv-step_id": this.state.currentStepId,
         "uv-step_name": stepDef.name,
       };
 
-      // Use prompt resolver to get prompt
       try {
-        return await this.promptResolver.resolve(stepDef.fallbackKey, uvVars);
+        return await this.promptResolver.resolve(
+          this.state.currentStepId,
+          uvVars,
+        );
       } catch {
         // Fallback if prompt resolution fails
       }
@@ -302,11 +303,10 @@ ${this.buildStepInstructions(stepDef)}
       };
 
       try {
-        const continuationKey = stepDef.fallbackKey.replace(
-          STEP_PHASE.INITIAL,
-          STEP_PHASE.CONTINUATION,
+        return await this.promptResolver.resolve(
+          this.state.currentStepId,
+          uvVars,
         );
-        return await this.promptResolver.resolve(continuationKey, uvVars);
       } catch {
         // Fallback if prompt resolution fails
       }

--- a/agents/completion/structured-signal.ts
+++ b/agents/completion/structured-signal.ts
@@ -44,7 +44,7 @@ export class StructuredSignalCompletionHandler extends BaseCompletionHandler {
       : "";
 
     if (this.promptResolver) {
-      return await this.promptResolver.resolve("initial_structured_signal", {
+      return await this.promptResolver.resolve("initial.structuredSignal", {
         "uv-signal_type": this.signalType,
         "uv-required_fields": JSON.stringify(this.requiredFields ?? {}),
       });
@@ -94,7 +94,7 @@ ${requiredFieldsDesc}
         ? this.formatIterationSummary(previousSummary)
         : "";
       return await this.promptResolver.resolve(
-        "continuation_structured_signal",
+        "continuation.structuredSignal",
         {
           "uv-iteration": String(completedIterations),
           "uv-signal_type": this.signalType,

--- a/agents/docs/design/05_core_architecture.md
+++ b/agents/docs/design/05_core_architecture.md
@@ -10,6 +10,30 @@ Agent は「設定で形を決め、単純なループで動き、完了サブ�
 - **Why**: ループを分けることで、進行と完了の意図を干渉させない
 - **How (最小限)**: ループは Step 定義と C3L プロンプト解決だけで制御する
 
+## Step 完了と Agent 完了
+
+Agent の実行には二つの「完了」が存在する。これらは異なる階層に属し、
+異なる責務が判定する。この区別を明示するのは、両者を混同すると 「Step
+が終わった＝Agent が終わった」と誤読され、Completion Loop を 経由せず Agent
+を終了させる実装が生まれるためである。
+
+```
+Agent 完了
+│  Completion Loop が検証し、成功を返したとき
+│
+└── Step 完了 (複数回発生する)
+      Flow が intent routing で次の Step へ遷移したとき
+```
+
+- **Step 完了**: 1 つの Step の作業が終わり、次の Step へ遷移すること。 Flow
+  ループの責務であり、intent（next / repeat / jump / handoff）で制御する。 Step
+  完了は Agent の状態を前進させるが、Agent を終了させない。
+- **Agent 完了**: Agent 全体の仕事が終わること。Completion Loop の責務であり、
+  外部検証（completionConditions）の結果だけが判定権を持つ。
+
+closing intent は「最後の Step が完了した」ことを示す Step 完了の特殊形であり、
+Completion Loop の起動トリガーである。closing intent 自体は Agent 完了ではない。
+
 ## 二重ループモデル
 
 ```
@@ -55,7 +79,6 @@ Flow ループは「前へ進むための重力」、Completion ループは「�
 ## Completion Loop
 
 - **What**: Flow ループから `completionSignal`（structured output 上の
-  `status: "completed"` や
   `next_action.action: "closing"`）を受け取ったときにだけ
   起動し、完了判定・最終処理・未完了時の指示を担う。
 - **Why**: 収束を担保するための専用ループを用意し、完了判定を手続き的に
@@ -64,12 +87,88 @@ Flow ループは「前へ進むための重力」、Completion ループは「�
 - **How (最小限)**:
   - Completion Loop も C3L の `steps/closure/*` プロンプトで制御する。
     ユーザーは docs/ に沿って同一の体系で編集できる。
-  - Structured Output（JSON Schema で定義）を読み取り、`completionConditions`
-    の検証結果、`pendingActions`、`retryPrompt` を Flow ループへ返す。
   - 失敗しても Flow ループは停止せず、Completion Loop が返した `retryPrompt`
     を次イテレーションのプロンプトとして使うだけである。
   - Closure Step から `closing` intent を受け取ったときだけ boundary hook を
     呼び出し、Issue close / release publish 等の副作用はここに限定する。
+
+### Completion Signal の定義
+
+`status: "completed"` と `next_action.action: "closing"` が両方存在するため、
+どちらが Completion Loop のトリガーかを厳密に定めないと、Flow
+が誤ったタイミングで Agent を完了させる原因となる。以下はその唯一の定義である。
+
+completionSignal とは、Closure Step が structured output で返す
+`next_action.action: "closing"` のことである。これ以外の値は completionSignal
+ではない。
+
+- `status: "completed"` → completionSignal **ではない**。Flow の参考情報。
+- `next_action.action: "next"` → Step 遷移の指示。Flow が処理する。
+- `next_action.action: "closing"` → **唯一の completionSignal**。 Completion
+  Loop を起動するトリガーとなる。
+
+completionSignal を受け取った Flow は、即座に Agent を完了させるのではなく、
+Completion Loop に制御を渡す。Agent 完了の判定権は Completion Loop にのみある。
+
+### Completion Loop の三段構成
+
+AI の自己申告（Closure Prompt）だけでは完了を信頼できず、外部検証（Validation）
+を挟まないと false positive が生じる。一方で検証結果をそのまま Flow に返すと
+判定ロジックが Flow に漏れる。三段に分けることで、各段の責務を単一にし、 Flow
+には最終判定（Verdict）だけを渡す構造を保つ。
+
+Completion Loop は以下の三段で構成される。while ではなく、単発の手続きである。
+
+```
+Stage 1: Closure Prompt
+  closurePrompt = resolve(c3l.closure, response, handoff)
+  closureResult = queryLLM(closurePrompt)
+  → Closure Step の AI に最終確認を促し、証跡を構造化する
+
+Stage 2: Validation
+  validation = runCompletionConditions(closureResult)
+  → completionConditions（外部コマンド）で成果物を機械的に検証する
+
+Stage 3: Verdict
+  if validation.allPassed: return { done: true }
+  else: return { done: false, retryPrompt: buildRetry(validation) }
+  → 検証結果に基づき、Agent 完了 or retryPrompt を Flow へ返す
+```
+
+Flow ループは Stage 3 の戻り値だけを受け取る。 done = true なら Agent
+を終了し、done = false なら retryPrompt を 次の iteration
+のプロンプトとして注入する。
+
+Completion Loop が Agent 完了の唯一の判定者であり、 Flow ループが直接 Agent
+を完了させることはない。
+
+## CompletionType と二重ループ
+
+完了の判定基準は Agent の用途によって異なる（Issue 完了、反復回数、外部状態
+等）。 しかし Flow ループの進行ロジックは共通である。Strategy
+パターンで判定ロジックだけを 差し替えることで、Flow
+ループに条件分岐を持ち込まずに多様な完了基準を実現する。
+
+CompletionHandler は Completion Loop の判定ロジックを差し替える Strategy
+である。 Flow ループの動作は CompletionType に依存しない。
+
+| CompletionType   | Flow ループ      | Completion Loop の判定基準             |
+| ---------------- | ---------------- | -------------------------------------- |
+| stepMachine      | Step Flow (必須) | Step 状態機械が終端到達                |
+| externalState    | Step Flow (推奨) | 外部リソースが目標状態に到達           |
+| iterationBudget  | Step Flow (任意) | N 回の iteration を消化                |
+| keywordSignal    | Step Flow (任意) | LLM 出力に特定キーワードを検出         |
+| structuredSignal | Step Flow (任意) | LLM 出力に特定 JSON 構造を検出         |
+| checkBudget      | Step Flow (任意) | N 回のステータスチェックを消化         |
+| composite        | Step Flow (任意) | 上記を AND/OR/FIRST で組み合わせ       |
+| custom           | Step Flow (任意) | 外部ファイルから動的ロードしたハンドラ |
+
+- **Flow ループ列**: Step Flow の利用要否。stepMachine は structuredGate
+  が必須。 他のタイプは Step Flow なしでも動作可能だが、利用を推奨する。
+- **Completion Loop 列**: CompletionHandler.isComplete() が何を見て判定するか。
+- **共通**: どの CompletionType でも、Flow が Agent
+  完了を直接判定することはない。 Flow は Step 遷移だけを担い、Agent 完了は
+  CompletionHandler に委譲する。
 
 ## データ引き継ぎ（handoff）
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.12.3";
+export const CLIMPT_VERSION = "1.12.4";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- fix(agent): use dot-format step IDs so CompletionHandlers resolve rich prompts from disk
- Add resolveWorkStepPrompt() to CompletionManager for work-step resolution
- Add 19 integration tests for handler→resolver step ID contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)