### PR TITLE
Release 1.13.1: patch version bump

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.13.0";
+export const CLIMPT_VERSION = "1.13.1";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Version bump to 1.13.1 (deno.json, src/version.ts)

## Test plan
- [x] `deno task ci` passed (7/7 stages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)