### PR TITLE
Release 1.13.5: validator fixes and schema enum discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.5] - 2026-03-15
+
+### Fixed
+- Flow validator now recognizes `entryStep` (singular) as BFS starting point for reachability checks (`flow-validator.ts`)
+- Template UV validator skips fallback template checks when no C3L prompt file exists (`template-uv-validator.ts`)
+- UV reachability validator reads `registry.runtimeUvVariables` and merges with hardcoded runtime variables (`uv-reachability-validator.ts`)
+
+### Changed
+- Blueprint schema enums converted to `oneOf`+`const`+`title` format for discoverability (`agent-blueprint.schema.json`)
+
+### Added
+- UV variable supply Channel 3 (VerdictHandler) documented in blueprint spec
+- Blueprint spec and schema added to docs manifest
+
 ## [1.13.4] - 2026-03-15
 
 ### Added

--- a/agents/config/flow-validator.ts
+++ b/agents/config/flow-validator.ts
@@ -153,6 +153,12 @@ export function validateFlowReachability(
     }
   }
 
+  // Also check entryStep (singular) as entry point
+  const entryStep = registry.entryStep;
+  if (typeof entryStep === "string" && allStepIds.has(entryStep)) {
+    entryPoints.add(entryStep);
+  }
+
   // -----------------------------------------------------------------------
   // 3. BFS from all entry points
   // -----------------------------------------------------------------------

--- a/agents/config/flow-validator_test.ts
+++ b/agents/config/flow-validator_test.ts
@@ -304,7 +304,67 @@ Deno.test("flow-validator - multiple entry points reaching different closures", 
 });
 
 // =============================================================================
-// 9. Integration test with real iterator registry
+// 9. entryStep (singular) as BFS starting point
+// =============================================================================
+
+Deno.test("flow-validator - entryStep (singular) reaches closure", () => {
+  const registry: Record<string, unknown> = {
+    entryStep: "initial.issue",
+    steps: {
+      "initial.issue": {
+        stepId: "initial.issue",
+        c2: "initial",
+        transitions: {
+          next: { target: "closure.issue" },
+        },
+      },
+      "closure.issue": {
+        stepId: "closure.issue",
+        c2: "closure",
+        transitions: {
+          closing: { target: null },
+        },
+      },
+    },
+  };
+
+  const result = validateFlowReachability(registry);
+
+  assertEquals(result.valid, true);
+  assertEquals(result.errors.length, 0);
+});
+
+Deno.test("flow-validator - entryStep pointing to non-existent step is skipped", () => {
+  const registry: Record<string, unknown> = {
+    entryStep: "nonexistent.step",
+    steps: {
+      "initial.issue": {
+        stepId: "initial.issue",
+        c2: "initial",
+        transitions: {
+          next: { target: "closure.issue" },
+        },
+      },
+      "closure.issue": {
+        stepId: "closure.issue",
+        c2: "closure",
+        transitions: {
+          closing: { target: null },
+        },
+      },
+    },
+  };
+
+  const result = validateFlowReachability(registry);
+
+  // No entry points -> BFS visits nothing -> closure unreachable -> error
+  assertEquals(result.valid, false);
+  const closureError = result.errors.find((e) => e.includes("closure"));
+  assertEquals(closureError !== undefined, true);
+});
+
+// =============================================================================
+// 10. Integration test with real iterator registry
 // =============================================================================
 
 Deno.test("flow-validator/integration - iterator steps_registry has valid flow", async () => {

--- a/agents/config/template-uv-validator.ts
+++ b/agents/config/template-uv-validator.ts
@@ -189,8 +189,14 @@ export async function validateTemplateUvConsistency(
       }
     }
 
-    // Source 2: Fallback template
-    if (fallbackKey !== null && fallbackProvider.hasTemplate(fallbackKey)) {
+    // Source 2: Fallback template (only when a C3L prompt file exists)
+    // When promptContent is null, the step has no C3L file and the fallback
+    // is a system-provided safety net — its UV requirements should not be
+    // imposed on the agent config.
+    if (
+      promptContent !== null && fallbackKey !== null &&
+      fallbackProvider.hasTemplate(fallbackKey)
+    ) {
       const fallbackTemplates = fallbackProvider.getTemplates();
       const fallbackContent = fallbackTemplates[fallbackKey];
       if (fallbackContent) {

--- a/agents/config/template-uv-validator.ts
+++ b/agents/config/template-uv-validator.ts
@@ -191,7 +191,7 @@ export async function validateTemplateUvConsistency(
 
     // Source 2: Fallback template (only when a C3L prompt file exists)
     // When promptContent is null, the step has no C3L file and the fallback
-    // is a system-provided safety net — its UV requirements should not be
+    // is a system-provided safety net -- its UV requirements should not be
     // imposed on the agent config.
     if (
       promptContent !== null && fallbackKey !== null &&

--- a/agents/config/template-uv-validator_test.ts
+++ b/agents/config/template-uv-validator_test.ts
@@ -198,11 +198,12 @@ Deno.test("template-uv-validator - missing prompt file is skipped", async () => 
 // 5. Fallback template contains {uv-issue} -> check against declarations
 // =============================================================================
 
-Deno.test("template-uv-validator - fallback template UV checked against declarations", async () => {
+Deno.test("template-uv-validator - fallback-only step skips UV check (no C3L file)", async () => {
   const dir = await Deno.makeTempDir();
   try {
     // No C3L prompt file — only fallback template
     // "initial_issue" fallback uses {uv-issue} (from DefaultFallbackProvider)
+    // Since no C3L file exists, fallback UV requirements should NOT be imposed.
     const registry = registryWith("initial.issue", {
       c2: "initial",
       c3: "issue",
@@ -213,16 +214,9 @@ Deno.test("template-uv-validator - fallback template UV checked against declarat
 
     const result = await validateTemplateUvConsistency(registry, dir, dir);
 
-    // The fallback template for "initial_issue" uses {uv-issue}, which is
-    // not declared in uvVariables -> error
-    assertEquals(result.valid, false);
-    assertEquals(
-      result.errors.some((e) =>
-        e.includes("initial.issue") && e.includes("uv-issue")
-      ),
-      true,
-      `Expected fallback UV error, got: ${JSON.stringify(result.errors)}`,
-    );
+    // Fallback-only: no C3L file means fallback UV variables are not checked
+    assertEquals(result.valid, true);
+    assertEquals(result.errors.length, 0);
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/agents/config/uv-reachability-validator.ts
+++ b/agents/config/uv-reachability-validator.ts
@@ -3,9 +3,10 @@
  *
  * Validates that each step's declared uvVariables have a known supply source:
  * - CLI parameters (from agent.json parameters)
- * - Runtime variables (iteration, completed_iterations, completion_keyword)
+ * - Runtime variables (hardcoded: iteration, completed_iterations, completion_keyword)
+ * - Registry-declared runtime variables (from registry.runtimeUvVariables keys)
  *
- * Variables not matching either source are flagged as errors.
+ * Variables not matching any source are flagged as errors.
  * Optional CLI parameters without defaults are flagged as warnings.
  *
  * Additionally validates prefix substitution consistency:
@@ -159,6 +160,15 @@ export function validateUvReachability(
   const parametersRaw = asRecord(agentDef.parameters) ?? {};
   const parameterKeys = new Set(Object.keys(parametersRaw));
 
+  // Merge hardcoded runtime variables with registry-declared runtimeUvVariables
+  const registryRuntimeVars = asRecord(registry.runtimeUvVariables);
+  const allRuntimeVars = new Set(RUNTIME_VARIABLES);
+  if (registryRuntimeVars) {
+    for (const key of Object.keys(registryRuntimeVars)) {
+      allRuntimeVars.add(key);
+    }
+  }
+
   for (const [stepId, stepDef] of Object.entries(stepsRaw)) {
     const step = asRecord(stepDef);
     if (!step) continue;
@@ -170,8 +180,8 @@ export function validateUvReachability(
       const varName = typeof varEntry === "string" ? varEntry : null;
       if (varName === null) continue;
 
-      // Runtime variable - always available
-      if (RUNTIME_VARIABLES.has(varName)) continue;
+      // Runtime variable - always available (hardcoded + registry-declared)
+      if (allRuntimeVars.has(varName)) continue;
 
       // CLI parameter - check existence and optionality
       if (parameterKeys.has(varName)) {

--- a/agents/config/uv-reachability-validator_test.ts
+++ b/agents/config/uv-reachability-validator_test.ts
@@ -261,6 +261,90 @@ Deno.test("validateUvReachability - multiple steps with mixed results", () => {
 });
 
 // =============================================================================
+// Registry runtimeUvVariables tests
+// =============================================================================
+
+Deno.test("validateUvReachability - registry runtimeUvVariables recognized as valid source", () => {
+  const registry: Record<string, unknown> = {
+    runtimeUvVariables: {
+      previous_summary: { source: "verdict-handler" },
+      remaining: { source: "verdict-handler" },
+      max_iterations: { source: "verdict-handler" },
+    },
+    steps: {
+      "step.check": {
+        uvVariables: ["previous_summary", "remaining", "max_iterations"],
+      },
+    },
+  };
+  const agent = agentWith({});
+
+  const result = validateUvReachability(registry, agent);
+
+  assertEquals(result.valid, true);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.warnings.length, 0);
+});
+
+Deno.test("validateUvReachability - registry runtimeUvVariables merged with hardcoded set", () => {
+  const registry: Record<string, unknown> = {
+    runtimeUvVariables: {
+      check_count: { source: "verdict-handler" },
+      max_checks: { source: "verdict-handler" },
+    },
+    steps: {
+      "step.check": {
+        uvVariables: ["iteration", "check_count", "max_checks"],
+      },
+    },
+  };
+  const agent = agentWith({});
+
+  const result = validateUvReachability(registry, agent);
+
+  assertEquals(result.valid, true);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.warnings.length, 0);
+});
+
+Deno.test("validateUvReachability - variable not in registry runtimeUvVariables still errors", () => {
+  const registry: Record<string, unknown> = {
+    runtimeUvVariables: {
+      previous_summary: { source: "verdict-handler" },
+    },
+    steps: {
+      "step.check": {
+        uvVariables: ["previous_summary", "undeclared_var"],
+      },
+    },
+  };
+  const agent = agentWith({});
+
+  const result = validateUvReachability(registry, agent);
+
+  assertEquals(result.valid, false);
+  assertEquals(result.errors.length, 1);
+  assertEquals(
+    result.errors[0].includes("undeclared_var"),
+    true,
+    `Expected error for "undeclared_var", got: ${result.errors[0]}`,
+  );
+});
+
+Deno.test("validateUvReachability - absent runtimeUvVariables field -> no change in behavior", () => {
+  const registry = registryWith("step.issue", {
+    uvVariables: ["iteration"],
+  });
+  const agent = agentWith({});
+
+  const result = validateUvReachability(registry, agent);
+
+  assertEquals(result.valid, true);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.warnings.length, 0);
+});
+
+// =============================================================================
 // Prefix substitution consistency tests
 // =============================================================================
 

--- a/agents/docs/builder/reference/steps_registry.yaml
+++ b/agents/docs/builder/reference/steps_registry.yaml
@@ -550,10 +550,13 @@ steps:
     # Description : User Variable names injected into prompt.
     # Type        : array of strings
     # Default     : []
-    # Why         : Lists the variable placeholders in the
-    #               prompt template. The runner resolves these
-    #               from CLI parameters or runtime state.
-    #               Missing variables produce empty strings.
+    # Why         : Lists the variable placeholders in the prompt template.
+    #               The runner resolves these from three supply channels:
+    #                 Channel 1: CLI parameters (agent.json parameters)
+    #                 Channel 2: Runner runtime (iteration, completed_iterations, completion_keyword)
+    #                 Channel 3: VerdictHandler (remaining, previous_summary, max_iterations, check_count, max_checks)
+    #               Channel 3 variables are supplied by VerdictHandler.buildContinuationPrompt()
+    #               via setUvVariables() interface. Missing variables produce empty strings.
     uvVariables: ["issue"]
 
     # usesStdin (optional)

--- a/agents/docs/design/07_prompt_system.md
+++ b/agents/docs/design/07_prompt_system.md
@@ -84,14 +84,31 @@ prompts/steps/continuation/manual/f_detailed.md
 
 User Variable。プロンプト内で `{uv-xxx}` で参照。
 
-| 変数                     | 説明             |
-| ------------------------ | ---------------- |
-| `uv-agent_name`          | Agent 識別子     |
-| `uv-completion_criteria` | 完了条件テキスト |
-| `uv-issue`               | Issue 番号       |
-| `uv-iteration`           | 現在の回数       |
-| `uv-max_iterations`      | 最大回数         |
-| `uv-completion_keyword`  | 完了キーワード   |
+| 変数                      | 説明             | 供給元                      |
+| ------------------------- | ---------------- | --------------------------- |
+| `uv-agent_name`           | Agent 識別子     | CLI parameter               |
+| `uv-completion_criteria`  | 完了条件テキスト | CLI parameter               |
+| `uv-issue`                | Issue 番号       | CLI parameter               |
+| `uv-iteration`            | 現在の回数       | Runner (Channel 2)          |
+| `uv-completed_iterations` | 完了済み回数     | Runner (Channel 2)          |
+| `uv-max_iterations`       | 最大回数         | Verdict Handler (Channel 3) |
+| `uv-completion_keyword`   | 完了キーワード   | Runner (Channel 2)          |
+| `uv-remaining`            | 残り回数         | Verdict Handler (Channel 3) |
+| `uv-previous_summary`     | 前回のサマリー   | Verdict Handler (Channel 3) |
+| `uv-check_count`          | 確認回数         | Verdict Handler (Channel 3) |
+| `uv-max_checks`           | 最大確認回数     | Verdict Handler (Channel 3) |
+
+### UV 変数の供給チャネル
+
+| Channel | 供給元                                   | 変数                                                                               |
+| ------- | ---------------------------------------- | ---------------------------------------------------------------------------------- |
+| 1       | CLI parameters (agent.json)              | agent.json の parameters に宣言された全変数                                        |
+| 2       | Runner runtime (buildUvVariables)        | iteration, completed_iterations, completion_keyword                                |
+| 3       | VerdictHandler (buildContinuationPrompt) | handler 固有。remaining, previous_summary, max_iterations, check_count, max_checks |
+
+Channel 3 は VerdictHandler が `promptResolver.resolve()`
+を呼ぶ際に独自に追加する変数。`setUvVariables()` で Channel 1+2
+の変数を受け取り、handler 固有の変数をマージして供給する。
 
 ## プロンプトテンプレート
 

--- a/agents/schemas/agent-blueprint.schema.json
+++ b/agents/schemas/agent-blueprint.schema.json
@@ -216,7 +216,11 @@
         },
         "defaultModel": {
           "type": "string",
-          "enum": ["sonnet", "opus", "haiku"],
+          "oneOf": [
+            { "const": "sonnet", "title": "Balanced speed and capability" },
+            { "const": "opus", "title": "Maximum capability" },
+            { "const": "haiku", "title": "Fastest, lightweight tasks" }
+          ],
           "description": "Default model for all steps. R-F13 (at runner level)."
         },
         "askUserAutoResponse": {
@@ -234,15 +238,36 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "poll:state",
-            "count:iteration",
-            "count:check",
-            "detect:keyword",
-            "detect:structured",
-            "detect:graph",
-            "meta:composite",
-            "meta:custom"
+          "oneOf": [
+            {
+              "const": "poll:state",
+              "title": "Complete when external resource reaches target state"
+            },
+            {
+              "const": "count:iteration",
+              "title": "Complete after N iterations"
+            },
+            {
+              "const": "count:check",
+              "title": "Complete after N status checks"
+            },
+            {
+              "const": "detect:keyword",
+              "title": "Complete when LLM outputs specific keyword"
+            },
+            {
+              "const": "detect:structured",
+              "title": "Complete when LLM outputs structured signal"
+            },
+            {
+              "const": "detect:graph",
+              "title": "Complete when step graph reaches terminal"
+            },
+            {
+              "const": "meta:composite",
+              "title": "Combine multiple conditions with and/or/first"
+            },
+            { "const": "meta:custom", "title": "Fully custom verdict handler" }
           ],
           "description": "How the agent determines verdict. R-F3."
         },
@@ -407,7 +432,11 @@
         },
         "operator": {
           "type": "string",
-          "enum": ["and", "or", "first"],
+          "oneOf": [
+            { "const": "and", "title": "All conditions must be met" },
+            { "const": "or", "title": "Any condition suffices" },
+            { "const": "first", "title": "First condition to complete wins" }
+          ],
           "description": "Logical operator for combining conditions (meta:composite)"
         },
         "conditions": {
@@ -468,7 +497,18 @@
         },
         "permissionMode": {
           "type": "string",
-          "enum": ["default", "plan", "acceptEdits", "bypassPermissions"],
+          "oneOf": [
+            { "const": "default", "title": "Standard permission prompts" },
+            {
+              "const": "plan",
+              "title": "Require plan approval before execution"
+            },
+            { "const": "acceptEdits", "title": "Auto-accept file edits" },
+            {
+              "const": "bypassPermissions",
+              "title": "Skip all permission prompts"
+            }
+          ],
           "description": "Claude permission mode. R-F4."
         },
         "sandbox": {
@@ -574,7 +614,14 @@
         },
         "defaultClosureAction": {
           "type": "string",
-          "enum": ["close", "label-only", "label-and-close"],
+          "oneOf": [
+            { "const": "close", "title": "Close the issue" },
+            { "const": "label-only", "title": "Add labels without closing" },
+            {
+              "const": "label-and-close",
+              "title": "Add labels and close the issue"
+            }
+          ],
           "default": "close",
           "description": "Default action for issue closure. R-F19."
         }
@@ -822,7 +869,20 @@
         },
         "stepKind": {
           "type": "string",
-          "enum": ["work", "verification", "closure"],
+          "oneOf": [
+            {
+              "const": "work",
+              "title": "Primary task execution (intents: next, repeat, jump, handoff)"
+            },
+            {
+              "const": "verification",
+              "title": "Quality gate check (intents: next, repeat, jump, escalate)"
+            },
+            {
+              "const": "closure",
+              "title": "Final completion step (intents: closing, repeat)"
+            }
+          ],
           "description": "Step kind for flow taxonomy. R-B10: required for flow steps. Determines allowed intents per R-B3."
         },
         "c2": {
@@ -862,7 +922,11 @@
         },
         "model": {
           "type": "string",
-          "enum": ["sonnet", "opus", "haiku"],
+          "oneOf": [
+            { "const": "sonnet", "title": "Balanced speed and capability" },
+            { "const": "opus", "title": "Maximum capability" },
+            { "const": "haiku", "title": "Fastest, lightweight tasks" }
+          ],
           "description": "Model override for this step. R-F13."
         },
         "priority": {
@@ -1013,13 +1077,25 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "next",
-              "repeat",
-              "jump",
-              "handoff",
-              "closing",
-              "escalate"
+            "oneOf": [
+              { "const": "next", "title": "Proceed to next step in flow" },
+              { "const": "repeat", "title": "Retry current step" },
+              {
+                "const": "jump",
+                "title": "Skip to a named target step (requires targetField)"
+              },
+              {
+                "const": "handoff",
+                "title": "Transfer context to another step (requires handoffFields)"
+              },
+              {
+                "const": "closing",
+                "title": "Begin completion sequence (closure steps only)"
+              },
+              {
+                "const": "escalate",
+                "title": "Escalate to higher authority (verification steps only)"
+              }
             ]
           },
           "minItems": 1,
@@ -1045,7 +1121,20 @@
         },
         "targetMode": {
           "type": "string",
-          "enum": ["explicit", "dynamic", "conditional"],
+          "oneOf": [
+            {
+              "const": "explicit",
+              "title": "Target step ID is hardcoded in transitions"
+            },
+            {
+              "const": "dynamic",
+              "title": "Target step ID comes from LLM output field"
+            },
+            {
+              "const": "conditional",
+              "title": "Target depends on output condition evaluation"
+            }
+          ],
           "default": "explicit",
           "description": "How target step IDs are determined. R-F14."
         },
@@ -1056,13 +1145,25 @@
         },
         "fallbackIntent": {
           "type": "string",
-          "enum": [
-            "next",
-            "repeat",
-            "jump",
-            "handoff",
-            "closing",
-            "escalate"
+          "oneOf": [
+            { "const": "next", "title": "Proceed to next step in flow" },
+            { "const": "repeat", "title": "Retry current step" },
+            {
+              "const": "jump",
+              "title": "Skip to a named target step (requires targetField)"
+            },
+            {
+              "const": "handoff",
+              "title": "Transfer context to another step (requires handoffFields)"
+            },
+            {
+              "const": "closing",
+              "title": "Begin completion sequence (closure steps only)"
+            },
+            {
+              "const": "escalate",
+              "title": "Escalate to higher authority (verification steps only)"
+            }
           ],
           "description": "Default intent if response parsing fails. R-B9: must be in STEP_KIND_ALLOWED_INTENTS[stepKind] (runtime validation)."
         }
@@ -1274,7 +1375,14 @@
       "properties": {
         "action": {
           "type": "string",
-          "enum": ["retry", "abort", "skip"],
+          "oneOf": [
+            {
+              "const": "retry",
+              "title": "Retry the step (requires maxAttempts)"
+            },
+            { "const": "abort", "title": "Stop execution immediately" },
+            { "const": "skip", "title": "Skip this step and continue" }
+          ],
           "description": "Failure action. R-C5."
         },
         "maxAttempts": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -468,6 +468,55 @@
       "category": "reference",
       "title": "サブエージェント",
       "bytes": 604674
+    },
+    {
+      "id": "blueprint-overview",
+      "path": "../agents/docs/builder/reference/blueprint/00-overview.md",
+      "category": "reference",
+      "title": "AgentBlueprint Language Overview",
+      "bytes": 2567
+    },
+    {
+      "id": "blueprint-structure",
+      "path": "../agents/docs/builder/reference/blueprint/01-structure.md",
+      "category": "reference",
+      "title": "AgentBlueprint Structure",
+      "bytes": 6950
+    },
+    {
+      "id": "blueprint-integrity-rules",
+      "path": "../agents/docs/builder/reference/blueprint/02-integrity-rules.md",
+      "category": "reference",
+      "title": "AgentBlueprint Integrity Rules (52 rules)",
+      "bytes": 20880
+    },
+    {
+      "id": "blueprint-constraints",
+      "path": "../agents/docs/builder/reference/blueprint/03-constraints.md",
+      "category": "reference",
+      "title": "AgentBlueprint Constraints",
+      "bytes": 2501
+    },
+    {
+      "id": "blueprint-terminology",
+      "path": "../agents/docs/builder/reference/blueprint/04-terminology.md",
+      "category": "reference",
+      "title": "AgentBlueprint Terminology",
+      "bytes": 7834
+    },
+    {
+      "id": "blueprint-examples",
+      "path": "../agents/docs/builder/reference/blueprint/05-examples.md",
+      "category": "reference",
+      "title": "AgentBlueprint Examples",
+      "bytes": 11833
+    },
+    {
+      "id": "schema-agent-blueprint",
+      "path": "../agents/schemas/agent-blueprint.schema.json",
+      "category": "reference",
+      "title": "AgentBlueprint JSON Schema",
+      "bytes": 45133
     }
   ]
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.13.4";
+export const CLIMPT_VERSION = "1.13.5";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Fix flow-validator to recognize `entryStep` (singular) as BFS entry point
- Fix template-uv-validator to skip fallback checks when no C3L prompt exists
- Fix uv-reachability-validator to read `registry.runtimeUvVariables`
- Add descriptive `oneOf`+`const`+`title` to 11 blueprint schema enums
- Document UV variable supply Channel 3 (VerdictHandler) in blueprint spec

## Test plan
- [ ] 961 tests pass (CI)
- [ ] 126 agents/config/ tests pass
- [ ] Blueprint examples validate with PATH errors only

🤖 Generated with [Claude Code](https://claude.com/claude-code)