### PR TITLE
Release 1.13.8

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,8 @@
 
 [English](README.md) | [日本語](README.ja.md)
 
-CLIプロンプト管理ツール。Iterator、Reviewerエージェントも含まれています。CLI以外にも、MCPやプラグインを通じて利用可能です。プラグインのスキルは専用のclimpt-agent（Claude Agent SDK経由）で実行されます。
+CLIプロンプト管理ツール。Iterator、Reviewerエージェントも含まれています。CLI以外にも、MCPやプラグインを通じて利用可能です。プラグインのスキルは専用のclimpt-agent（Claude
+Agent SDK経由）で実行されます。
 
 ## クイックスタート
 
@@ -20,10 +21,10 @@ echo "ログインバグを修正" | deno run -A jsr:@aidevtool/climpt git decid
 
 Climptは事前に設定されたプロンプトを整理し、1つのコマンドで呼び出します。3つの利用方法：
 
-| 方法 | 説明 |
-|------|------|
-| **CLI** | コマンドラインから直接実行 |
-| **MCP** | Model Context ProtocolでClaude/Cursorと連携 |
+| 方法       | 説明                                        |
+| ---------- | ------------------------------------------- |
+| **CLI**    | コマンドラインから直接実行                  |
+| **MCP**    | Model Context ProtocolでClaude/Cursorと連携 |
 | **Plugin** | climpt-agentを使用したClaude Codeプラグイン |
 
 ### 詳細を知る
@@ -39,6 +40,7 @@ deno run -A jsr:@aidevtool/climpt <profile> <directive> <layer> [options]
 ```
 
 **例：**
+
 ```bash
 # 課題をタスクに分解
 deno run -A jsr:@aidevtool/climpt breakdown to task --from=issue.md --adaptation=detailed
@@ -49,13 +51,13 @@ echo "エラーログ" | deno run -A jsr:@aidevtool/climpt diagnose trace stack 
 
 ### 主要オプション
 
-| オプション | 短縮形 | 説明 |
-|------------|--------|------|
-| `--from` | `-f` | 入力ファイル |
-| `--destination` | `-o` | 出力パス |
-| `--edition` | `-e` | プロンプトエディション |
-| `--adaptation` | `-a` | プロンプトバリエーション |
-| `--uv-*` | - | カスタム変数 |
+| オプション      | 短縮形 | 説明                     |
+| --------------- | ------ | ------------------------ |
+| `--from`        | `-f`   | 入力ファイル             |
+| `--destination` | `-o`   | 出力パス                 |
+| `--edition`     | `-e`   | プロンプトエディション   |
+| `--adaptation`  | `-a`   | プロンプトバリエーション |
+| `--uv-*`        | -      | カスタム変数             |
 
 📖 [CLI完全リファレンス](https://tettuan.github.io/climpt/)
 
@@ -68,6 +70,7 @@ echo "エラーログ" | deno run -A jsr:@aidevtool/climpt diagnose trace stack 
 ```
 
 **テンプレート変数：**
+
 - `{input_text}` - 標準入力からのテキスト
 - `{input_text_file}` - 入力ファイルパス
 - `{destination_path}` - 出力パス
@@ -103,13 +106,15 @@ MCPでClaudeまたはCursorと連携：
 ```
 
 機能：
+
 - 自然言語によるコマンド実行
 - Gitワークフロー（コミット、ブランチ、PR）
 - プロンプト管理操作
 
 ## エージェント
 
-**前提条件**: エージェントには GitHub CLI (`gh`) のインストールと認証、および GitHub にプッシュされた Git リポジトリが必要です。
+**前提条件**: エージェントには GitHub CLI (`gh`) のインストールと認証、および
+GitHub にプッシュされた Git リポジトリが必要です。
 
 ### エージェント構成
 
@@ -124,6 +129,7 @@ MCPでClaudeまたはCursorと連携：
 ```
 
 **agent.json** の主要プロパティ：
+
 - `name`, `displayName`, `version` - エージェント識別情報
 - `runner.verdict.type` - 実行モード（後述）
 - `runner.boundaries.allowedTools` - エージェントが利用可能なツール
@@ -140,7 +146,8 @@ deno task agent --init --agent {agent-name}
 
 テンプレートファイルを含むディレクトリ構成が生成されます。
 
-**ビルダードキュメント**: エージェント設定とカスタマイズの詳細ガイドは [`agents/docs/builder/`](agents/docs/builder/) を参照。
+**ビルダードキュメント**: エージェント設定とカスタマイズの詳細ガイドは
+[`agents/docs/builder/`](agents/docs/builder/) を参照。
 
 ### エージェント実行
 
@@ -160,46 +167,70 @@ deno task agent --agent {name} --iterate-max 10
 
 ### 判定タイプ
 
-| タイプ | 説明 |
-|--------|------|
-| `poll:state` | 外部リソース状態を監視（GitHub issue/project、ファイル、API） |
-| `count:iteration` | 指定回数（`maxIterations`）反復実行 |
-| `count:check` | 指定回数（`maxChecks`）ステータス確認 |
-| `detect:keyword` | エージェントが `verdictKeyword` を出力したら終了 |
-| `detect:structured` | 構造化アクションブロック出力を検出（`signalType`） |
-| `detect:graph` | ステップステートマシンに従う（`registryPath`, `entryStep`） |
-| `meta:composite` | 複合条件（and/or/first演算子） |
-| `meta:custom` | カスタムハンドラー（`handlerPath`）を使用 |
+| タイプ              | 説明                                                          |
+| ------------------- | ------------------------------------------------------------- |
+| `poll:state`        | 外部リソース状態を監視（GitHub issue/project、ファイル、API） |
+| `count:iteration`   | 指定回数（`maxIterations`）反復実行                           |
+| `count:check`       | 指定回数（`maxChecks`）ステータス確認                         |
+| `detect:keyword`    | エージェントが `verdictKeyword` を出力したら終了              |
+| `detect:structured` | 構造化アクションブロック出力を検出（`signalType`）            |
+| `detect:graph`      | ステップステートマシンに従う（`registryPath`, `entryStep`）   |
+| `meta:composite`    | 複合条件（and/or/first演算子）                                |
+| `meta:custom`       | カスタムハンドラー（`handlerPath`）を使用                     |
 
 ### 組み込みエージェント
 
-**Iterator Agent** - 自律開発：
+エージェントは Runner（`./agents/runner`）経由で `--agent` を指定して実行する：
+
 ```bash
-deno run -A jsr:@aidevtool/climpt/agents/iterator --issue 123
+# Iterator - 自律開発
+deno run -A jsr:@aidevtool/climpt/agents/runner --agent iterator --issue 123
+
+# Reviewer - コードレビュー
+deno run -A jsr:@aidevtool/climpt/agents/runner --agent reviewer --project 1
+
+# Facilitator - プロジェクト監視
+deno run -A jsr:@aidevtool/climpt/agents/runner --agent facilitator --project 1
 ```
 
-**Reviewer Agent** - コードレビュー：
+### エージェントドキュメント
+
+| ドキュメント           | パス                                         | 説明                                          |
+| ---------------------- | -------------------------------------------- | --------------------------------------------- |
+| クイックスタート       | `agents/docs/builder/01_quickstart.md`       | エージェント作成ガイド                        |
+| 定義リファレンス       | `agents/docs/builder/02_agent_definition.md` | agent.json フィールド                         |
+| YAML リファレンス      | `agents/docs/builder/reference/`             | 全フィールドのコメント付き解説                |
+| トラブルシューティング | `agents/docs/builder/05_troubleshooting.md`  | よくある問題と解決策                          |
+| 設計ドキュメント       | `agents/docs/design/`                        | アーキテクチャとコンセプト                    |
+| JSON スキーマ          | `agents/schemas/`                            | agent.schema.json, steps_registry.schema.json |
+
+CLIオプションは `deno task agent --help` を参照。設定の検証は
+`deno task agent --agent <name> --validate` で実行可能。
+
+## Orchestrator
+
+Orchestrator はラベル駆動の状態機械で複数エージェントを協調させる。エージェント
+ではなく、エージェントをディスパッチし Phase 遷移を管理する独立したエントリー
+ポイントである。
+
 ```bash
-deno run -A jsr:@aidevtool/climpt/agents/reviewer --project 1
+# 単一 issue を処理
+deno task workflow --issue 123
+
+# ラベルでフィルタして処理（batch モード）
+deno task workflow --label ready --state open
+
+# ドライラン
+deno task workflow --issue 123 --dry-run --verbose
 ```
 
-**Facilitator Agent** - プロジェクト監視：
 ```bash
-deno run -A jsr:@aidevtool/climpt/agents/facilitator --project 1
+# JSR エントリーポイント
+deno run -A jsr:@aidevtool/climpt/agents/orchestrator --issue 123
 ```
 
-### ドキュメント
-
-| ドキュメント | パス | 説明 |
-|-------------|------|------|
-| クイックスタート | `agents/docs/builder/01_quickstart.md` | エージェント作成ガイド |
-| 定義リファレンス | `agents/docs/builder/02_agent_definition.md` | agent.json フィールド |
-| YAML リファレンス | `agents/docs/builder/reference/` | 全フィールドのコメント付き解説 |
-| トラブルシューティング | `agents/docs/builder/05_troubleshooting.md` | よくある問題と解決策 |
-| 設計ドキュメント | `agents/docs/design/` | アーキテクチャとコンセプト |
-| JSON スキーマ | `agents/schemas/` | agent.schema.json, steps_registry.schema.json |
-
-CLIオプションは `deno task agent --help` を参照。設定の検証は `deno task agent --agent <name> --validate` で実行可能。
+ワークフローは `.agent/workflow.json` で設定する。詳細は
+[ワークフローガイド](docs/guides/ja/15-workflow-guide.md)を参照。
 
 ### 設定例
 
@@ -280,7 +311,8 @@ deno run -Ar jsr:@aidevtool/climpt/docs install ./docs
 
 ## Examples（E2E動作確認）
 
-[`examples/`](examples/) ディレクトリには、ユースケースごとに整理された実行可能なシェルスクリプトが含まれています。リリース前にこれらを実行して、エンドツーエンドの動作を確認してください：
+[`examples/`](examples/)
+ディレクトリには、ユースケースごとに整理された実行可能なシェルスクリプトが含まれています。リリース前にこれらを実行して、エンドツーエンドの動作を確認してください：
 
 ```bash
 # スクリプトに実行権限を付与
@@ -296,14 +328,14 @@ chmod +x examples/**/*.sh examples/*.sh
 ./examples/07_clean.sh
 ```
 
-| フォルダ | 説明 |
-|----------|------|
-| [01_setup/](examples/01_setup/) | インストールと初期化 |
-| [02_cli_basic/](examples/02_cli_basic/) | 基本CLIコマンド：分解、要約、欠陥分析 |
-| [03_mcp/](examples/03_mcp/) | MCPサーバー設定とIDE連携 |
-| [04_docs/](examples/04_docs/) | ドキュメントインストーラー |
-| [05_agents/](examples/05_agents/) | エージェントフレームワーク（iterator、reviewer） |
-| [06_registry/](examples/06_registry/) | レジストリ生成と構造 |
+| フォルダ                                | 説明                                             |
+| --------------------------------------- | ------------------------------------------------ |
+| [01_setup/](examples/01_setup/)         | インストールと初期化                             |
+| [02_cli_basic/](examples/02_cli_basic/) | 基本CLIコマンド：分解、要約、欠陥分析            |
+| [03_mcp/](examples/03_mcp/)             | MCPサーバー設定とIDE連携                         |
+| [04_docs/](examples/04_docs/)           | ドキュメントインストーラー                       |
+| [05_agents/](examples/05_agents/)       | エージェントフレームワーク（iterator、reviewer） |
+| [06_registry/](examples/06_registry/)   | レジストリ生成と構造                             |
 
 詳細は [`examples/README.md`](examples/README.md) を参照。
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [English](README.md) | [日本語](README.ja.md)
 
-CLI Prompt Management Tool. Agents: Iterator, Reviewer also included. Besides CLI, it is available through MCP and plugins. The plugin skills run on a dedicated climpt-agent (via the Claude Agent SDK).
+CLI Prompt Management Tool. Agents: Iterator, Reviewer also included. Besides
+CLI, it is available through MCP and plugins. The plugin skills run on a
+dedicated climpt-agent (via the Claude Agent SDK).
 
 ## Quick Start
 
@@ -18,17 +20,19 @@ echo "Fix login bug" | deno run -A jsr:@aidevtool/climpt git decide-branch worki
 
 ## What is Climpt?
 
-Climpt organizes pre-configured prompts and invokes them with a single command. Three ways to use:
+Climpt organizes pre-configured prompts and invokes them with a single command.
+Three ways to use:
 
-| Method | Description |
-|--------|-------------|
-| **CLI** | Direct command-line execution |
-| **MCP** | Integration with Claude/Cursor via Model Context Protocol |
-| **Plugin** | Claude Code plugin with climpt-agent |
+| Method     | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| **CLI**    | Direct command-line execution                             |
+| **MCP**    | Integration with Claude/Cursor via Model Context Protocol |
+| **Plugin** | Claude Code plugin with climpt-agent                      |
 
 ### Learn More
 
-Explore interactively: [Climpt NotebookLM](https://notebooklm.google.com/notebook/6a186ac9-70b2-4734-ad46-359e26043507)
+Explore interactively:
+[Climpt NotebookLM](https://notebooklm.google.com/notebook/6a186ac9-70b2-4734-ad46-359e26043507)
 
 ## CLI Usage
 
@@ -39,6 +43,7 @@ deno run -A jsr:@aidevtool/climpt <profile> <directive> <layer> [options]
 ```
 
 **Example:**
+
 ```bash
 # Break down issue into tasks
 deno run -A jsr:@aidevtool/climpt breakdown to task --from=issue.md --adaptation=detailed
@@ -49,13 +54,13 @@ echo "error log" | deno run -A jsr:@aidevtool/climpt diagnose trace stack -o=./o
 
 ### Key Options
 
-| Option | Short | Description |
-|--------|-------|-------------|
-| `--from` | `-f` | Input file |
-| `--destination` | `-o` | Output path |
-| `--edition` | `-e` | Prompt edition |
-| `--adaptation` | `-a` | Prompt variation |
-| `--uv-*` | - | Custom variables |
+| Option          | Short | Description      |
+| --------------- | ----- | ---------------- |
+| `--from`        | `-f`  | Input file       |
+| `--destination` | `-o`  | Output path      |
+| `--edition`     | `-e`  | Prompt edition   |
+| `--adaptation`  | `-a`  | Prompt variation |
+| `--uv-*`        | -     | Custom variables |
 
 📖 [Full CLI Reference](https://tettuan.github.io/climpt/)
 
@@ -68,6 +73,7 @@ Prompts are organized in `.agent/climpt/prompts/`:
 ```
 
 **Template Variables:**
+
 - `{input_text}` - Text from stdin
 - `{input_text_file}` - Input file path
 - `{destination_path}` - Output path
@@ -103,13 +109,15 @@ Integrate with Claude or Cursor via MCP:
 ```
 
 Features:
+
 - Natural language command execution
 - Git workflows (commit, branch, PR)
 - Prompt management operations
 
 ## Agents
 
-**Prerequisites**: Agents require GitHub CLI (`gh`) installed and authenticated, plus a Git repository pushed to GitHub.
+**Prerequisites**: Agents require GitHub CLI (`gh`) installed and authenticated,
+plus a Git repository pushed to GitHub.
 
 ### Agent Structure
 
@@ -124,6 +132,7 @@ Each agent is defined in `.agent/{agent-name}/` with:
 ```
 
 **agent.json** key properties:
+
 - `name`, `displayName`, `version` - Agent identification
 - `runner.verdict.type` - Execution mode (see below)
 - `runner.boundaries.allowedTools` - Available tools for the agent
@@ -140,7 +149,8 @@ deno task agent --init --agent {agent-name}
 
 This generates the directory structure with template files.
 
-**Builder Documentation**: For detailed guides on agent configuration and customization, see [`agents/docs/builder/`](agents/docs/builder/).
+**Builder Documentation**: For detailed guides on agent configuration and
+customization, see [`agents/docs/builder/`](agents/docs/builder/).
 
 ### Running Agents
 
@@ -157,46 +167,71 @@ deno task agent --agent {name} --iterate-max 10
 
 ### Verdict Types
 
-| Type | Description |
-|------|-------------|
-| `poll:state` | Monitors external resource state (GitHub issue/project, file, API) |
-| `count:iteration` | Runs for specified iterations (`maxIterations`) |
-| `count:check` | Runs for specified status checks (`maxChecks`) |
-| `detect:keyword` | Exits when agent outputs `verdictKeyword` |
-| `detect:structured` | Detects structured action block output (`signalType`) |
-| `detect:graph` | Follows step state machine (`registryPath`, `entryStep`) |
-| `meta:composite` | Combined conditions with operator (and/or/first) |
-| `meta:custom` | Uses custom handler (`handlerPath`) |
+| Type                | Description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
+| `poll:state`        | Monitors external resource state (GitHub issue/project, file, API) |
+| `count:iteration`   | Runs for specified iterations (`maxIterations`)                    |
+| `count:check`       | Runs for specified status checks (`maxChecks`)                     |
+| `detect:keyword`    | Exits when agent outputs `verdictKeyword`                          |
+| `detect:structured` | Detects structured action block output (`signalType`)              |
+| `detect:graph`      | Follows step state machine (`registryPath`, `entryStep`)           |
+| `meta:composite`    | Combined conditions with operator (and/or/first)                   |
+| `meta:custom`       | Uses custom handler (`handlerPath`)                                |
 
 ### Built-in Agents
 
-**Iterator Agent** - Autonomous development:
+Agents are run via the runner (`./agents/runner`) with `--agent`:
+
 ```bash
-deno run -A jsr:@aidevtool/climpt/agents/iterator --issue 123
+# Iterator - Autonomous development
+deno run -A jsr:@aidevtool/climpt/agents/runner --agent iterator --issue 123
+
+# Reviewer - Code review
+deno run -A jsr:@aidevtool/climpt/agents/runner --agent reviewer --project 1
+
+# Facilitator - Project monitoring
+deno run -A jsr:@aidevtool/climpt/agents/runner --agent facilitator --project 1
 ```
 
-**Reviewer Agent** - Code review:
+### Agent Documentation
+
+| Document             | Path                                         | Description                                   |
+| -------------------- | -------------------------------------------- | --------------------------------------------- |
+| Quick Start          | `agents/docs/builder/01_quickstart.md`       | Agent creation guide                          |
+| Definition Reference | `agents/docs/builder/02_agent_definition.md` | agent.json fields                             |
+| YAML Reference       | `agents/docs/builder/reference/`             | All fields with comments                      |
+| Troubleshooting      | `agents/docs/builder/05_troubleshooting.md`  | Common issues and solutions                   |
+| Design Docs          | `agents/docs/design/`                        | Architecture and concepts                     |
+| JSON Schemas         | `agents/schemas/`                            | agent.schema.json, steps_registry.schema.json |
+
+Use `deno task agent --help` for CLI options. Use
+`deno task agent --agent <name> --validate` to validate configuration without
+running.
+
+## Orchestrator
+
+The orchestrator coordinates multiple agents through a label-driven state
+machine. It is not an agent — it is a separate entry point that dispatches
+agents and manages phase transitions via GitHub labels.
+
 ```bash
-deno run -A jsr:@aidevtool/climpt/agents/reviewer --project 1
+# Process a single issue
+deno task workflow --issue 123
+
+# Process issues filtered by label (batch mode)
+deno task workflow --label ready --state open
+
+# Dry run
+deno task workflow --issue 123 --dry-run --verbose
 ```
 
-**Facilitator Agent** - Project monitoring:
 ```bash
-deno run -A jsr:@aidevtool/climpt/agents/facilitator --project 1
+# JSR entry point
+deno run -A jsr:@aidevtool/climpt/agents/orchestrator --issue 123
 ```
 
-### Documentation
-
-| Document | Path | Description |
-|----------|------|-------------|
-| Quick Start | `agents/docs/builder/01_quickstart.md` | Agent creation guide |
-| Definition Reference | `agents/docs/builder/02_agent_definition.md` | agent.json fields |
-| YAML Reference | `agents/docs/builder/reference/` | All fields with comments |
-| Troubleshooting | `agents/docs/builder/05_troubleshooting.md` | Common issues and solutions |
-| Design Docs | `agents/docs/design/` | Architecture and concepts |
-| JSON Schemas | `agents/schemas/` | agent.schema.json, steps_registry.schema.json |
-
-Use `deno task agent --help` for CLI options. Use `deno task agent --agent <name> --validate` to validate configuration without running.
+Configure workflows in `.agent/workflow.json`. See
+[Workflow Guide](docs/guides/en/15-workflow-guide.md) for details.
 
 ### Configuration Example
 
@@ -245,7 +280,8 @@ Minimal `agent.json`:
 }
 ```
 
-> `required` defaults to `false` when omitted; parameters without it are treated as optional.
+> `required` defaults to `false` when omitted; parameters without it are treated
+> as optional.
 
 📖 [Agent Documentation](https://tettuan.github.io/climpt/)
 
@@ -285,8 +321,9 @@ The `-r` flag (`--reload`) forces re-download of the latest version from JSR.
 
 ## Examples (E2E Verification)
 
-The [`examples/`](examples/) directory contains executable shell scripts organized
-by use case. Run these before each release to verify end-to-end functionality:
+The [`examples/`](examples/) directory contains executable shell scripts
+organized by use case. Run these before each release to verify end-to-end
+functionality:
 
 ```bash
 # Make scripts executable
@@ -302,14 +339,14 @@ chmod +x examples/**/*.sh examples/*.sh
 ./examples/07_clean.sh
 ```
 
-| Folder | Description |
-|--------|-------------|
-| [01_setup/](examples/01_setup/) | Installation and initialization |
+| Folder                                  | Description                                   |
+| --------------------------------------- | --------------------------------------------- |
+| [01_setup/](examples/01_setup/)         | Installation and initialization               |
 | [02_cli_basic/](examples/02_cli_basic/) | Core CLI commands: decompose, summary, defect |
-| [03_mcp/](examples/03_mcp/) | MCP server setup and IDE integration |
-| [04_docs/](examples/04_docs/) | Documentation installer |
-| [05_agents/](examples/05_agents/) | Agent framework (iterator, reviewer) |
-| [06_registry/](examples/06_registry/) | Registry generation and structure |
+| [03_mcp/](examples/03_mcp/)             | MCP server setup and IDE integration          |
+| [04_docs/](examples/04_docs/)           | Documentation installer                       |
+| [05_agents/](examples/05_agents/)       | Agent framework (iterator, reviewer)          |
+| [06_registry/](examples/06_registry/)   | Registry generation and structure             |
 
 See [`examples/README.md`](examples/README.md) for full details.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -107,6 +107,30 @@ deno run -A agents/scripts/run-agent.ts --list
 deno run -A agents/scripts/run-agent.ts --agent reviewer --target src/
 ```
 
+## Workflow (Orchestrator)
+
+The orchestrator coordinates multiple agents through a label-driven state
+machine. It reads GitHub issue labels, dispatches agents, and updates labels
+based on outcomes.
+
+```bash
+# Process a single issue
+deno run -A agents/scripts/run-workflow.ts --issue 123
+
+# Or use deno task
+deno task workflow --issue 123
+
+# Batch: process issues filtered by label
+deno task workflow --label ready --state open
+
+# Dry run (no label changes)
+deno task workflow --issue 123 --dry-run --verbose
+```
+
+Configure workflows in `.agent/workflow.json`. See
+[Workflow Guide](../docs/guides/en/15-workflow-guide.md) and
+[design/12_orchestrator.md](./docs/design/12_orchestrator.md) for details.
+
 ## Directory Structure
 
 ```
@@ -115,6 +139,7 @@ agents/
 +-- CLAUDE.md                 # Agent development guidelines
 +-- scripts/
 |   +-- run-agent.ts          # Unified agent runner CLI
+|   +-- run-workflow.ts       # Workflow orchestrator CLI
 +-- runner/                   # Core runner implementation
 |   +-- runner.ts             # AgentRunner (dual-loop core)
 |   +-- builder.ts            # Dependency injection builder
@@ -132,6 +157,13 @@ agents/
 |   +-- types.ts
 |   +-- worktree.ts
 |   +-- git-utils.ts
++-- orchestrator/             # Workflow orchestrator
+|   +-- orchestrator.ts       # Main loop (label → dispatch → transition)
+|   +-- label-resolver.ts     # Label → Phase → Agent resolution
+|   +-- phase-transition.ts   # Phase transition & label change computation
+|   +-- dispatcher.ts         # Agent dispatch via runner
+|   +-- workflow-loader.ts    # workflow.json loader & validator
+|   +-- workflow-types.ts     # Type definitions
 +-- validators/               # Pre-close validators
 |   +-- registry.ts
 |   +-- plugins/
@@ -448,6 +480,8 @@ Design:
 - [design/09_contracts.md](./docs/design/09_contracts.md) - Contracts & I/O
 - [design/10_extension_points.md](./docs/design/10_extension_points.md) -
   Extension points
+- [design/12_orchestrator.md](./docs/design/12_orchestrator.md) - Workflow
+  orchestrator design
 
 Builder/Guides:
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",
@@ -23,7 +23,8 @@
     "./docs": "./docs.ts",
     "./docs/cli": "./src/docs/cli.ts",
     "./agents": "./agents/mod.ts",
-    "./agents/runner": "./agents/scripts/run-agent.ts"
+    "./agents/runner": "./agents/scripts/run-agent.ts",
+    "./agents/orchestrator": "./agents/scripts/run-workflow.ts"
   },
   "include": [
     "README.md",
@@ -124,7 +125,14 @@
       "examples/",
       "*.ts"
     ],
-    "exclude": ["dist/", "node_modules/", "tmp/", "**/*_test.ts", "tests/"],
+    "exclude": [
+      "dist/",
+      "node_modules/",
+      "tmp/",
+      "examples/tmp/",
+      "**/*_test.ts",
+      "tests/"
+    ],
     "rules": {
       "tags": ["recommended"],
       "include": [

--- a/docs/guides/en/15-workflow-guide.md
+++ b/docs/guides/en/15-workflow-guide.md
@@ -70,6 +70,20 @@ deno task workflow --label ready --state open
 
 ## workflow.json Structure
 
+### Top-Level Fields
+
+| Field          | Required | Default                     | Description                                                   |
+| -------------- | -------- | --------------------------- | ------------------------------------------------------------- |
+| `version`      | yes      | —                           | Schema version (e.g., `"1.0.0"`)                              |
+| `phases`       | yes      | —                           | Phase definitions (see below)                                 |
+| `labelMapping` | yes      | —                           | GitHub label → phase ID mapping                               |
+| `agents`       | yes      | —                           | Agent definitions (see below)                                 |
+| `rules`        | yes      | —                           | Execution constraints (see below)                             |
+| `labelPrefix`  | no       | —                           | Label namespace (e.g., `"docs"` → labels become `docs:ready`) |
+| `issueStore`   | no       | `{ path: ".agent/issues" }` | Local issue storage directory                                 |
+| `handoff`      | no       | —                           | Inter-agent handoff comment templates                         |
+| `prioritizer`  | no       | —                           | Prioritizer agent configuration (required for `--prioritize`) |
+
 ### phases
 
 Defines the workflow states. Each phase has a `type`:
@@ -77,6 +91,12 @@ Defines the workflow states. Each phase has a `type`:
 - `actionable` — An agent runs. Requires `agent` and `priority`.
 - `terminal` — Workflow ends.
 - `blocking` — Waits for human intervention.
+
+| Field      | Required       | Description                                                      |
+| ---------- | -------------- | ---------------------------------------------------------------- |
+| `type`     | yes            | `"actionable"`, `"terminal"`, or `"blocking"`                    |
+| `priority` | for actionable | Lower number = higher priority. Used when multiple labels match. |
+| `agent`    | for actionable | Agent ID to dispatch (must exist in `agents`)                    |
 
 ### labelMapping
 
@@ -92,12 +112,30 @@ Defines agent behavior:
 - **Validator** (`role: "validator"`) — Multiple outputs via `outputPhases` map
   (e.g., `approved` → complete, `rejected` → revision).
 
+| Field           | Required        | Description                                                 |
+| --------------- | --------------- | ----------------------------------------------------------- |
+| `role`          | yes             | `"transformer"` or `"validator"`                            |
+| `directory`     | no              | Agent directory name under `.agent/` (defaults to agent ID) |
+| `outputPhase`   | for transformer | Target phase on success                                     |
+| `outputPhases`  | for validator   | Outcome key → target phase mapping                          |
+| `fallbackPhase` | no              | Target phase on error (typically `"blocked"`)               |
+
 ### rules
 
-| Field        | Default | Description                            |
-| ------------ | ------- | -------------------------------------- |
-| maxCycles    | 5       | Max transitions per issue (loop guard) |
-| cycleDelayMs | 5000    | Delay between cycles (ms)              |
+| Field          | Default | Description                            |
+| -------------- | ------- | -------------------------------------- |
+| `maxCycles`    | 5       | Max transitions per issue (loop guard) |
+| `cycleDelayMs` | 5000    | Delay between cycles (ms)              |
+
+### prioritizer
+
+Required when using `--prioritize`. Configures the priority assignment agent.
+
+| Field          | Required | Description                                                   |
+| -------------- | -------- | ------------------------------------------------------------- |
+| `agent`        | yes      | Agent ID to dispatch for prioritization                       |
+| `labels`       | yes      | Allowed priority labels in order (e.g., `["P1", "P2", "P3"]`) |
+| `defaultLabel` | no       | Fallback label when priority is missing or invalid            |
 
 ## Running Workflows
 
@@ -124,20 +162,38 @@ deno task workflow --label ready --prioritize
 deno task workflow --label P1 --label docs --state open --limit 10
 ```
 
+### `--label` vs `labelPrefix`
+
+`--label` and `labelPrefix` are independent concepts:
+
+| Concept       | Where           | What it does                                                                |
+| ------------- | --------------- | --------------------------------------------------------------------------- |
+| `--label`     | CLI argument    | Filters which issues to fetch from GitHub (`gh issue list --label <value>`) |
+| `labelPrefix` | `workflow.json` | Namespaces workflow labels (e.g., `ready` becomes `docs:ready`)             |
+
+`--label` selects issues to process. `labelPrefix` controls how the orchestrator
+reads and writes phase labels during transitions. They do not affect each other.
+
+Example: `--label docs` fetches issues that have a `docs` label. The
+orchestrator then reads the issue's other labels (e.g., `ready`) to resolve the
+current phase and manages transitions using `labelMapping`. The `docs` label
+itself is not in `labelMapping`, so it remains untouched throughout the
+workflow.
+
 ### CLI Options
 
-| Option         | Type    | Default                | Description                               |
-| -------------- | ------- | ---------------------- | ----------------------------------------- |
-| `--issue`      | number  | —                      | Process a single issue (skips batch sync) |
-| `--workflow`   | string  | `.agent/workflow.json` | Workflow file path                        |
-| `--label`      | string  | —                      | Label filter (repeatable, batch mode)     |
-| `--repo`       | string  | current                | Repository (`owner/repo`)                 |
-| `--state`      | string  | `open`                 | `open` / `closed` / `all`                 |
-| `--limit`      | number  | `30`                   | Max issues to fetch                       |
-| `--prioritize` | boolean | false                  | Run prioritizer only (batch mode)         |
-| `--verbose`    | boolean | false                  | Detailed log output                       |
-| `--dry-run`    | boolean | false                  | Show what would happen without acting     |
-| `--local`      | boolean | false                  | Use local IssueStore (skip GitHub sync)   |
+| Option         | Type    | Default                | Description                                  |
+| -------------- | ------- | ---------------------- | -------------------------------------------- |
+| `--issue`      | number  | —                      | Process a single issue (skips batch sync)    |
+| `--workflow`   | string  | `.agent/workflow.json` | Workflow file path                           |
+| `--label`      | string  | —                      | GitHub issue filter (repeatable, batch mode) |
+| `--repo`       | string  | current                | Repository (`owner/repo`)                    |
+| `--state`      | string  | `open`                 | `open` / `closed` / `all`                    |
+| `--limit`      | number  | `30`                   | Max issues to fetch                          |
+| `--prioritize` | boolean | false                  | Run prioritizer only (batch mode)            |
+| `--verbose`    | boolean | false                  | Detailed log output                          |
+| `--dry-run`    | boolean | false                  | Show what would happen without acting        |
+| `--local`      | boolean | false                  | Use local IssueStore (skip GitHub sync)      |
 
 ## Understanding Output
 

--- a/docs/guides/ja/15-workflow-guide.md
+++ b/docs/guides/ja/15-workflow-guide.md
@@ -70,6 +70,20 @@ deno task workflow --label ready --state open
 
 ## workflow.json の構造
 
+### トップレベルフィールド
+
+| フィールド     | 必須 | デフォルト                  | 説明                                                          |
+| -------------- | ---- | --------------------------- | ------------------------------------------------------------- |
+| `version`      | yes  | —                           | スキーマバージョン（例: `"1.0.0"`）                           |
+| `phases`       | yes  | —                           | Phase 定義（後述）                                            |
+| `labelMapping` | yes  | —                           | GitHub ラベル → phase ID マッピング                           |
+| `agents`       | yes  | —                           | Agent 定義（後述）                                            |
+| `rules`        | yes  | —                           | 実行制約（後述）                                              |
+| `labelPrefix`  | no   | —                           | ラベル名前空間（例: `"docs"` → ラベルが `docs:ready` になる） |
+| `issueStore`   | no   | `{ path: ".agent/issues" }` | ローカル issue ストアのディレクトリ                           |
+| `handoff`      | no   | —                           | Agent 間ハンドオフのコメントテンプレート                      |
+| `prioritizer`  | no   | —                           | Prioritizer Agent 設定（`--prioritize` に必須）               |
+
 ### phases
 
 ワークフローの状態を定義する。各 phase は `type` を持つ:
@@ -77,6 +91,12 @@ deno task workflow --label ready --state open
 - `actionable` — Agent が実行される。`agent` と `priority` が必須。
 - `terminal` — ワークフロー完了。
 - `blocking` — 人間の介入待ち。
+
+| フィールド | 必須            | 説明                                                       |
+| ---------- | --------------- | ---------------------------------------------------------- |
+| `type`     | yes             | `"actionable"`、`"terminal"`、または `"blocking"`          |
+| `priority` | actionable のみ | 小さいほど高優先。複数ラベルがマッチしたときの選択に使用。 |
+| `agent`    | actionable のみ | ディスパッチする Agent ID（`agents` に存在する必要がある） |
 
 ### labelMapping
 
@@ -92,12 +112,30 @@ Agent の動作を定義:
 - **Validator** (`role: "validator"`) — 複数出力。`outputPhases`
   で判定結果に応じた遷移先を定義。
 
+| フィールド      | 必須             | 説明                                                       |
+| --------------- | ---------------- | ---------------------------------------------------------- |
+| `role`          | yes              | `"transformer"` または `"validator"`                       |
+| `directory`     | no               | `.agent/` 配下の Agent ディレクトリ名（省略時は Agent ID） |
+| `outputPhase`   | transformer のみ | 成功時の遷移先 phase                                       |
+| `outputPhases`  | validator のみ   | 判定キー → 遷移先 phase のマッピング                       |
+| `fallbackPhase` | no               | エラー時の遷移先 phase（通常 `"blocked"`）                 |
+
 ### rules
 
-| フィールド   | デフォルト | 説明                       |
-| ------------ | ---------- | -------------------------- |
-| maxCycles    | 5          | issue あたりの最大遷移回数 |
-| cycleDelayMs | 5000       | サイクル間の待機（ミリ秒） |
+| フィールド     | デフォルト | 説明                       |
+| -------------- | ---------- | -------------------------- |
+| `maxCycles`    | 5          | issue あたりの最大遷移回数 |
+| `cycleDelayMs` | 5000       | サイクル間の待機（ミリ秒） |
+
+### prioritizer
+
+`--prioritize` 使用時に必須。優先度ラベル付与 Agent の設定。
+
+| フィールド     | 必須 | 説明                                                         |
+| -------------- | ---- | ------------------------------------------------------------ |
+| `agent`        | yes  | 優先度付与に使用する Agent ID                                |
+| `labels`       | yes  | 許可する優先度ラベルの順序リスト（例: `["P1", "P2", "P3"]`） |
+| `defaultLabel` | no   | 優先度が未設定・無効な場合のフォールバックラベル             |
 
 ## ワークフローの実行
 
@@ -124,13 +162,30 @@ deno task workflow --label ready --prioritize
 deno task workflow --label P1 --label docs --state open --limit 10
 ```
 
+### `--label` と `labelPrefix` の違い
+
+`--label` と `labelPrefix` は独立した概念である:
+
+| 概念          | 設定場所        | 役割                                                                        |
+| ------------- | --------------- | --------------------------------------------------------------------------- |
+| `--label`     | CLI 引数        | GitHub から取得する issue のフィルタ（`gh issue list --label <値>` に変換） |
+| `labelPrefix` | `workflow.json` | Phase 遷移ラベルの名前空間（例: `ready` → `docs:ready`）                    |
+
+`--label` は処理対象の issue を選別する。`labelPrefix` は遷移時のラベル読み書き
+を制御する。両者は互いに影響しない。
+
+例: `--label docs` は `docs` ラベルが付いた issue を取得する。Orchestrator
+はその issue の他のラベル（例: `ready`）から現在の phase を解決し、
+`labelMapping` に従って遷移を管理する。`docs` ラベル自体は `labelMapping`
+に含まれないため、ワークフロー全体を通じて変更されない。
+
 ### CLI オプション
 
 | オプション     | 型      | デフォルト             | 説明                                          |
 | -------------- | ------- | ---------------------- | --------------------------------------------- |
 | `--issue`      | number  | —                      | 単一 issue を処理（batch sync をスキップ）    |
 | `--workflow`   | string  | `.agent/workflow.json` | workflow ファイルパス                         |
-| `--label`      | string  | —                      | ラベルフィルタ（複数指定可、batch 用）        |
+| `--label`      | string  | —                      | GitHub issue フィルタ（複数指定可、batch 用） |
 | `--repo`       | string  | カレント               | リポジトリ（`owner/repo`）                    |
 | `--state`      | string  | `open`                 | `open` / `closed` / `all`                     |
 | `--limit`      | number  | `30`                   | 最大取得 issue 数                             |

--- a/docs/internal/index.md
+++ b/docs/internal/index.md
@@ -83,6 +83,8 @@ Combines multiple search queries:
 | Registry Loading             | `src/mcp/registry.ts`                    |
 | Agent Runner                 | `agents/runner/`                         |
 | Agent Configuration          | `agents/config/`                         |
+| Workflow Orchestrator        | `agents/orchestrator/`                   |
+| Workflow CLI                 | `agents/scripts/run-workflow.ts`         |
 
 ## Related Documentation
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.13.7";
+export const CLIMPT_VERSION = "1.13.8";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Add orchestrator as top-level section in README (EN/JA) alongside agents
- Add `./agents/orchestrator` JSR export entry point
- Document `--label` vs `labelPrefix` distinction in workflow guides
- Add `examples/tmp/` to lint exclude to prevent false CI failures

## Test plan
- [x] Local CI 7/7 stages passed
- [x] Remote CI passed on release/1.13.8 → develop PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)