### PR TITLE
Release 1.13.9: fix stale orchestrator lock detection

### DIFF
--- a/agents/orchestrator/issue-store.ts
+++ b/agents/orchestrator/issue-store.ts
@@ -15,6 +15,20 @@
 
 import type { IssueWorkflowState } from "./workflow-types.ts";
 
+/** Check if a process is still running. Uses `kill -0` (no signal sent). */
+function isProcessAlive(pid: number): boolean {
+  try {
+    const cmd = new Deno.Command("kill", {
+      args: ["-0", String(pid)],
+      stdout: "null",
+      stderr: "null",
+    });
+    return cmd.outputSync().code === 0;
+  } catch {
+    return false;
+  }
+}
+
 /** Issue metadata stored in meta.json */
 export interface IssueMeta {
   number: number;
@@ -195,7 +209,8 @@ export class IssueStore {
    * priority ordering.
    *
    * Returns a release function on success, or `null` if already locked.
-   * Stale locks (older than 30 minutes) are automatically cleaned up.
+   * Stale locks are detected by checking if the owning PID is still alive.
+   * Falls back to a 30-minute timeout to guard against PID recycling.
    */
   async acquireLock(
     workflowId: string,
@@ -203,20 +218,8 @@ export class IssueStore {
     await Deno.mkdir(this.#storePath, { recursive: true });
     const lockPath = `${this.#storePath}/.lock.${workflowId}`;
 
-    // Check for stale lock (older than 30 minutes)
-    try {
-      const stat = await Deno.stat(lockPath);
-      if (stat.mtime) {
-        const ageMs = Date.now() - stat.mtime.getTime();
-        if (ageMs > 30 * 60 * 1000) {
-          await Deno.remove(lockPath);
-        }
-      }
-    } catch (error) {
-      if (!(error instanceof Deno.errors.NotFound)) {
-        throw error;
-      }
-    }
+    // Check for stale lock
+    await this.#cleanStaleLock(lockPath);
 
     let file: Deno.FsFile;
     try {
@@ -228,7 +231,7 @@ export class IssueStore {
       throw error;
     }
 
-    // Write PID and timestamp for diagnostics
+    // Write PID and timestamp for stale detection
     const info = JSON.stringify({
       pid: Deno.pid,
       acquiredAt: new Date().toISOString(),
@@ -245,6 +248,45 @@ export class IssueStore {
         }
       },
     };
+  }
+
+  /**
+   * Remove a lock file if the owning process is no longer alive,
+   * or if the lock is older than 30 minutes (PID recycling guard).
+   */
+  async #cleanStaleLock(lockPath: string): Promise<void> {
+    let text: string;
+    try {
+      text = await Deno.readTextFile(lockPath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return;
+      throw error;
+    }
+
+    let stale = false;
+    try {
+      const info = JSON.parse(text) as { pid: number; acquiredAt: string };
+      if (!isProcessAlive(info.pid)) {
+        stale = true;
+      } else {
+        // PID alive — fall back to time-based check for PID recycling
+        const ageMs = Date.now() - new Date(info.acquiredAt).getTime();
+        if (ageMs > 30 * 60 * 1000) {
+          stale = true;
+        }
+      }
+    } catch {
+      // Corrupt lock file — treat as stale
+      stale = true;
+    }
+
+    if (stale) {
+      try {
+        await Deno.remove(lockPath);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) throw error;
+      }
+    }
   }
 
   /** Get issue directory path. */

--- a/agents/orchestrator/issue-store_test.ts
+++ b/agents/orchestrator/issue-store_test.ts
@@ -435,3 +435,43 @@ Deno.test("acquireLock: different workflowIds do not conflict", async () => {
     await Deno.remove(tmp, { recursive: true });
   }
 });
+
+Deno.test("acquireLock: stale lock from dead PID is cleaned up", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const store = new IssueStore(tmp);
+    const lockPath = `${tmp}/.lock.default`;
+
+    // Simulate a leftover lock from a dead process (PID 999999 is very unlikely alive)
+    await Deno.mkdir(tmp, { recursive: true });
+    await Deno.writeTextFile(
+      lockPath,
+      JSON.stringify({ pid: 999999, acquiredAt: new Date().toISOString() }),
+    );
+
+    // acquireLock should detect dead PID and reclaim
+    const lock = await store.acquireLock("default");
+    assertEquals(lock !== null, true);
+    await lock!.release();
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("acquireLock: corrupt lock file is treated as stale", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    const store = new IssueStore(tmp);
+    const lockPath = `${tmp}/.lock.default`;
+
+    // Write garbage to lock file
+    await Deno.mkdir(tmp, { recursive: true });
+    await Deno.writeTextFile(lockPath, "not json");
+
+    const lock = await store.acquireLock("default");
+    assertEquals(lock !== null, true);
+    await lock!.release();
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});

--- a/agents/orchestrator/orchestrator-logger.ts
+++ b/agents/orchestrator/orchestrator-logger.ts
@@ -1,0 +1,87 @@
+/**
+ * Orchestrator Logger
+ *
+ * File-based JSONL logger for orchestrator workflow execution.
+ * Always writes to `tmp/logs/orchestrator/session-{timestamp}.jsonl`.
+ * Console output is controlled by the `verbose` flag.
+ *
+ * Reuses shared logging infrastructure (JsonlWriter, rotateLogFiles).
+ */
+
+import { join } from "@std/path";
+import {
+  AgentLogger,
+  JsonlWriter,
+  rotateLogFiles,
+} from "../shared/logging/mod.ts";
+
+const LOG_DIR = "tmp/logs/orchestrator";
+const MAX_FILES = 50;
+
+export class OrchestratorLogger {
+  #logger: AgentLogger;
+  #verbose: boolean;
+
+  private constructor(logger: AgentLogger, verbose: boolean) {
+    this.#logger = logger;
+    this.#verbose = verbose;
+  }
+
+  /** Create and initialize a new orchestrator logger session. */
+  static async create(
+    cwd: string,
+    options?: { verbose?: boolean; correlationId?: string },
+  ): Promise<OrchestratorLogger> {
+    const logDir = join(cwd, LOG_DIR);
+    await rotateLogFiles(logDir, MAX_FILES);
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const logPath = join(logDir, `session-${timestamp}.jsonl`);
+
+    const writer = new JsonlWriter(logPath);
+    await writer.initialize();
+
+    const logger = new AgentLogger(writer, options?.correlationId);
+    return new OrchestratorLogger(logger, options?.verbose ?? false);
+  }
+
+  /** Log info-level event. Always writes to file; console only if verbose. */
+  async info(
+    message: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    if (this.#verbose) {
+      // deno-lint-ignore no-console
+      console.log(`[orchestrator] ${message}`);
+    }
+    await this.#logger.write("info", message, metadata);
+  }
+
+  /** Log warn-level event. Always writes to file and console. */
+  async warn(
+    message: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    // deno-lint-ignore no-console
+    console.warn(`[orchestrator] ${message}`);
+    await this.#logger.write("warn", message, metadata);
+  }
+
+  /** Log error-level event. Always writes to file and console. */
+  async error(
+    message: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    // deno-lint-ignore no-console
+    console.error(`[orchestrator] ${message}`);
+    await this.#logger.write("error", message, metadata);
+  }
+
+  async close(): Promise<void> {
+    await this.#logger.close();
+  }
+
+  getLogPath(): string {
+    return this.#logger.getLogPath();
+  }
+}

--- a/agents/orchestrator/orchestrator.ts
+++ b/agents/orchestrator/orchestrator.ts
@@ -30,6 +30,7 @@ import { OutboxProcessor } from "./outbox-processor.ts";
 import { Prioritizer } from "./prioritizer.ts";
 import { Queue } from "./queue.ts";
 import { wfBatchPrioritizeMissingConfig } from "../shared/errors/config-errors.ts";
+import { OrchestratorLogger } from "./orchestrator-logger.ts";
 
 export type { OrchestratorOptions, OrchestratorResult };
 
@@ -60,25 +61,43 @@ export class Orchestrator {
     issueNumber: number,
     options?: OrchestratorOptions,
     store?: IssueStore,
+    logger?: OrchestratorLogger,
   ): Promise<OrchestratorResult> {
-    return await this.#runInner(
-      issueNumber,
-      options,
-      store,
-      this.workflowId,
-    );
+    const ownsLogger = !logger;
+    const log = logger ??
+      await OrchestratorLogger.create(this.#cwd, {
+        verbose: options?.verbose,
+      });
+    try {
+      return await this.#runInner(
+        issueNumber,
+        options,
+        store,
+        this.workflowId,
+        log,
+      );
+    } finally {
+      if (ownsLogger) await log.close();
+    }
   }
 
   async #runInner(
     issueNumber: number,
-    options?: OrchestratorOptions,
-    store?: IssueStore,
-    workflowId?: string,
+    options: OrchestratorOptions | undefined,
+    store: IssueStore | undefined,
+    workflowId: string | undefined,
+    log: OrchestratorLogger,
   ): Promise<OrchestratorResult> {
-    const verbose = options?.verbose ?? false;
     const dryRun = options?.dryRun ?? false;
     const maxCycles = this.#config.rules.maxCycles;
     const wfId = workflowId ?? this.workflowId;
+
+    await log.info(`Run start issue #${issueNumber}`, {
+      event: "run_start",
+      issueNumber,
+      workflowId: wfId,
+      dryRun,
+    });
 
     // Restore cycle tracker from persisted state if available
     let tracker: CycleTracker;
@@ -109,20 +128,26 @@ export class Orchestrator {
           currentLabels = await this.#github.getIssueLabels(issueNumber);
         }
       } catch (error) {
-        if (verbose) {
-          this.#log(
-            `Failed to get labels for issue #${issueNumber}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
-        }
+        const msg = error instanceof Error ? error.message : String(error);
+        // deno-lint-ignore no-await-in-loop
+        await log.error(
+          `Failed to get labels for issue #${issueNumber}: ${msg}`,
+          {
+            event: "labels_error",
+            issueNumber,
+            error: msg,
+          },
+        );
         status = "blocked";
         break;
       }
 
-      if (verbose) {
-        this.#log(`Labels: [${currentLabels.join(", ")}]`);
-      }
+      // deno-lint-ignore no-await-in-loop
+      await log.info(`Labels: [${currentLabels.join(", ")}]`, {
+        event: "labels",
+        issueNumber,
+        labels: currentLabels,
+      });
 
       // Step 4: Resolve phase
       // First check for terminal/blocking phases before resolving actionable
@@ -132,9 +157,13 @@ export class Orchestrator {
         status = terminalOrBlocking.phase.type === "terminal"
           ? "completed"
           : "blocked";
-        if (verbose) {
-          this.#log(`Phase "${finalPhase}" is ${status}`);
-        }
+        // deno-lint-ignore no-await-in-loop
+        await log.info(`Phase "${finalPhase}" is ${status}`, {
+          event: "phase_terminal_or_blocked",
+          issueNumber,
+          phase: finalPhase,
+          status,
+        });
         break;
       }
 
@@ -142,26 +171,34 @@ export class Orchestrator {
       if (resolved === null) {
         finalPhase = "unknown";
         status = "blocked";
-        if (verbose) {
-          this.#log("No actionable phase found, blocking");
-        }
+        // deno-lint-ignore no-await-in-loop
+        await log.info("No actionable phase found, blocking", {
+          event: "phase_unresolved",
+          issueNumber,
+        });
         break;
       }
 
       const { phaseId } = resolved;
       finalPhase = phaseId;
 
-      if (verbose) {
-        this.#log(`Resolved phase: "${phaseId}"`);
-      }
+      // deno-lint-ignore no-await-in-loop
+      await log.info(`Resolved phase: "${phaseId}"`, {
+        event: "phase_resolved",
+        issueNumber,
+        phase: phaseId,
+      });
 
       // Step 5: Resolve agent
       const agentResolution = resolveAgent(phaseId, this.#config);
       if (agentResolution === null) {
         status = "blocked";
-        if (verbose) {
-          this.#log(`No agent found for phase "${phaseId}"`);
-        }
+        // deno-lint-ignore no-await-in-loop
+        await log.warn(`No agent found for phase "${phaseId}"`, {
+          event: "agent_unresolved",
+          issueNumber,
+          phase: phaseId,
+        });
         break;
       }
 
@@ -170,30 +207,37 @@ export class Orchestrator {
       // Step 6: Cycle check
       if (tracker.isExceeded(issueNumber)) {
         status = "cycle_exceeded";
-        if (verbose) {
-          this.#log(
-            `Cycle limit exceeded (${
-              tracker.getCount(issueNumber)
-            }/${this.#config.rules.maxCycles})`,
-          );
-        }
+        // deno-lint-ignore no-await-in-loop
+        await log.warn(
+          `Cycle limit exceeded (${
+            tracker.getCount(issueNumber)
+          }/${maxCycles})`,
+          {
+            event: "cycle_exceeded",
+            issueNumber,
+            cycleCount: tracker.getCount(issueNumber),
+            maxCycles,
+          },
+        );
         break;
       }
 
       // dry-run: log what would happen, skip dispatch
       if (dryRun) {
-        if (verbose) {
-          this.#log(
-            `[dry-run] Would dispatch agent "${agentId}" for issue #${issueNumber}`,
-          );
-        }
+        // deno-lint-ignore no-await-in-loop
+        await log.info(
+          `[dry-run] Would dispatch agent "${agentId}" for issue #${issueNumber}`,
+          { event: "dry_run", issueNumber, agent: agentId },
+        );
         status = "dry-run";
         break;
       }
 
-      if (verbose) {
-        this.#log(`Dispatching agent "${agentId}" for issue #${issueNumber}`);
-      }
+      // deno-lint-ignore no-await-in-loop
+      await log.info(
+        `Dispatching agent "${agentId}" for issue #${issueNumber}`,
+        { event: "dispatch", issueNumber, agent: agentId },
+      );
 
       // Step 7: Dispatch agent
       // deno-lint-ignore no-await-in-loop
@@ -201,17 +245,23 @@ export class Orchestrator {
         agentId,
         issueNumber,
         {
-          verbose,
+          verbose: options?.verbose ?? false,
           issueStorePath: store?.storePath,
           outboxPath: store?.getOutboxPath(issueNumber),
         },
       );
 
-      if (verbose) {
-        this.#log(
-          `Agent "${agentId}" outcome: "${dispatchResult.outcome}" (${dispatchResult.durationMs}ms)`,
-        );
-      }
+      // deno-lint-ignore no-await-in-loop
+      await log.info(
+        `Agent "${agentId}" outcome: "${dispatchResult.outcome}" (${dispatchResult.durationMs}ms)`,
+        {
+          event: "dispatch_result",
+          issueNumber,
+          agent: agentId,
+          outcome: dispatchResult.outcome,
+          durationMs: dispatchResult.durationMs,
+        },
+      );
 
       // Step 7b: Process outbox after agent dispatch (when store available)
       if (store) {
@@ -233,14 +283,21 @@ export class Orchestrator {
         this.#config,
       );
 
-      if (verbose) {
-        this.#log(
-          `Transition: "${phaseId}" -> "${targetPhase}" ` +
-            `(remove: [${labelsToRemove.join(", ")}], add: [${
-              labelsToAdd.join(", ")
-            }])`,
-        );
-      }
+      // deno-lint-ignore no-await-in-loop
+      await log.info(
+        `Transition: "${phaseId}" -> "${targetPhase}" ` +
+          `(remove: [${labelsToRemove.join(", ")}], add: [${
+            labelsToAdd.join(", ")
+          }])`,
+        {
+          event: "transition",
+          issueNumber,
+          fromPhase: phaseId,
+          toPhase: targetPhase,
+          labelsToRemove,
+          labelsToAdd,
+        },
+      );
 
       // Step 10: Update labels
       if (!dryRun) {
@@ -252,13 +309,12 @@ export class Orchestrator {
             labelsToAdd,
           );
         } catch (error) {
-          if (verbose) {
-            this.#log(
-              `Failed to update labels for issue #${issueNumber}: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            );
-          }
+          const msg = error instanceof Error ? error.message : String(error);
+          // deno-lint-ignore no-await-in-loop
+          await log.warn(
+            `Failed to update labels for issue #${issueNumber}: ${msg}`,
+            { event: "label_update_failed", issueNumber, error: msg },
+          );
           // Label update failure is not fatal; continue to next cycle
         }
 
@@ -338,13 +394,20 @@ export class Orchestrator {
       }
     }
 
-    return {
+    const result: OrchestratorResult = {
       issueNumber,
       finalPhase,
       cycleCount: tracker.getCount(issueNumber),
       history: tracker.getHistory(issueNumber),
       status,
     };
+
+    await log.info(
+      `Run end issue #${issueNumber}: ${status} at "${finalPhase}" (${result.cycleCount} cycles)`,
+      { event: "run_end", ...result },
+    );
+
+    return result;
   }
 
   /**
@@ -398,60 +461,78 @@ export class Orchestrator {
     return s[0].toUpperCase() + s.slice(1);
   }
 
-  #log(message: string): void {
-    // deno-lint-ignore no-console
-    console.log(`[orchestrator] ${message}`);
-  }
-
   async runBatch(
     criteria: IssueCriteria,
     options?: BatchOptions,
   ): Promise<BatchResult> {
-    const storeConfig = this.#config.issueStore ?? { path: ".agent/issues" };
-    const storePath = join(this.#cwd, storeConfig.path);
-    const store = new IssueStore(storePath);
-
-    // 0. Workflow-level lock -- prevents concurrent batches from
-    //    breaking priority ordering. Different workflows (different
-    //    labelPrefix) use separate locks and never block each other.
-    const wfId = this.workflowId;
-    const lock = await store.acquireLock(wfId);
-    if (lock === null) {
-      if (options?.verbose) {
-        this.#log(
-          `Workflow "${wfId}" is already running, aborting batch`,
-        );
-      }
-      return {
-        processed: [],
-        skipped: [],
-        totalIssues: 0,
-        status: "failed",
-      };
-    }
+    const log = await OrchestratorLogger.create(this.#cwd, {
+      verbose: options?.verbose,
+    });
 
     try {
-      return await this.#runBatchInner(store, criteria, options);
+      const storeConfig = this.#config.issueStore ?? { path: ".agent/issues" };
+      const storePath = join(this.#cwd, storeConfig.path);
+      const store = new IssueStore(storePath);
+
+      const wfId = this.workflowId;
+      await log.info(`Batch start workflow "${wfId}"`, {
+        event: "batch_start",
+        workflowId: wfId,
+        criteria,
+      });
+
+      // 0. Workflow-level lock
+      const lock = await store.acquireLock(wfId);
+      if (lock === null) {
+        await log.warn(
+          `Workflow "${wfId}" is already running, aborting batch`,
+          { event: "lock_failed", workflowId: wfId },
+        );
+        return {
+          processed: [],
+          skipped: [],
+          totalIssues: 0,
+          status: "failed",
+        };
+      }
+
+      await log.info("Lock acquired", {
+        event: "lock_acquired",
+        workflowId: wfId,
+      });
+
+      try {
+        return await this.#runBatchInner(store, criteria, options, log);
+      } finally {
+        await lock.release();
+      }
     } finally {
-      await lock.release();
+      await log.close();
     }
   }
 
   async #runBatchInner(
     store: IssueStore,
     criteria: IssueCriteria,
-    options?: BatchOptions,
+    options: BatchOptions | undefined,
+    log: OrchestratorLogger,
   ): Promise<BatchResult> {
     const syncer = new IssueSyncer(this.#github, store);
 
     // 1. Sync issues from gh to local store
     const issueNumbers = await syncer.sync(criteria);
+    await log.info(`Synced ${issueNumbers.length} issues`, {
+      event: "sync_complete",
+      issueCount: issueNumbers.length,
+      issueNumbers,
+    });
 
     // 2. If --prioritize mode
     if (options?.prioritizeOnly) {
       if (!this.#config.prioritizer) {
         throw wfBatchPrioritizeMissingConfig();
       }
+      await log.info("Running prioritizer", { event: "prioritize_start" });
       const prioritizer = new Prioritizer(
         this.#config.prioritizer,
         store,
@@ -478,6 +559,13 @@ export class Orchestrator {
           await syncer.pushLabels(issue, oldPriorityLabels, [priority]);
         }
       }
+      await log.info(
+        `Prioritization complete: ${priorityResult.assignments.length} assignments`,
+        {
+          event: "prioritize_end",
+          assignmentCount: priorityResult.assignments.length,
+        },
+      );
       return {
         processed: [],
         skipped: [],
@@ -496,23 +584,51 @@ export class Orchestrator {
     const queue = new Queue(this.#config, store, priorityConfig);
     const queueItems = await queue.buildQueue(issueNumbers);
 
+    await log.info(`Queue built: ${queueItems.length} actionable issues`, {
+      event: "queue_built",
+      queueSize: queueItems.length,
+      issues: queueItems.map((q) => q.issueNumber),
+    });
+
     // 4. Process each issue
     const processed: OrchestratorResult[] = [];
     const skipped: { issueNumber: number; reason: string }[] = [];
     let errorCount = 0;
 
-    for (const item of queueItems) {
+    for (let i = 0; i < queueItems.length; i++) {
+      const item = queueItems[i];
+      // deno-lint-ignore no-await-in-loop
+      await log.info(
+        `Processing issue #${item.issueNumber} (${i + 1}/${queueItems.length})`,
+        {
+          event: "issue_start",
+          issueNumber: item.issueNumber,
+          index: i + 1,
+          total: queueItems.length,
+        },
+      );
       try {
-        // Use existing run() with store for single-truth-source processing
         // deno-lint-ignore no-await-in-loop
-        const result = await this.run(item.issueNumber, options, store);
+        const result = await this.run(
+          item.issueNumber,
+          options,
+          store,
+          log,
+        );
         processed.push(result);
       } catch (error) {
         errorCount++;
-        skipped.push({
-          issueNumber: item.issueNumber,
-          reason: error instanceof Error ? error.message : String(error),
-        });
+        const reason = error instanceof Error ? error.message : String(error);
+        skipped.push({ issueNumber: item.issueNumber, reason });
+        // deno-lint-ignore no-await-in-loop
+        await log.error(
+          `Issue #${item.issueNumber} failed: ${reason}`,
+          {
+            event: "issue_error",
+            issueNumber: item.issueNumber,
+            error: reason,
+          },
+        );
       }
     }
 
@@ -523,11 +639,23 @@ export class Orchestrator {
       }
     }
 
+    const batchStatus = errorCount > 0 ? "partial" : "completed";
+    await log.info(
+      `Batch end: ${processed.length} processed, ${skipped.length} skipped, status=${batchStatus}`,
+      {
+        event: "batch_end",
+        processedCount: processed.length,
+        skippedCount: skipped.length,
+        totalIssues: issueNumbers.length,
+        status: batchStatus,
+      },
+    );
+
     return {
       processed,
       skipped,
       totalIssues: issueNumbers.length,
-      status: errorCount > 0 ? "partial" : "completed",
+      status: batchStatus,
     };
   }
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.13.8",
+  "version": "1.13.9",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.13.8";
+export const CLIMPT_VERSION = "1.13.9";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- Fix stale orchestrator lock files blocking batch runs after process crashes
- Detect dead PIDs via `kill -0` for immediate lock reclamation instead of 30-minute timeout
- Handle corrupt lock files as stale

## Test plan
- [x] `deno task ci` — 1132 tests passed
- [x] New tests: stale lock from dead PID, corrupt lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)