### PR TITLE
Release 1.13.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.22] - 2026-04-08
+
+### Added
+- `closeOnComplete` option for orchestrator terminal phases (#455)
+
+### Fixed
+- Route `detect:graph` verdict to orchestrator outputPhases (#454)
+- Detect continuation-only UV variables in `initial.*` steps (#453)
+- Add `getLastVerdict` to mock VerdictHandlers and fix lint
+
+### Changed
+- Promote `getLastVerdict` to VerdictHandler interface
+
 ## [1.13.21] - 2026-04-07
 
 ### Added

--- a/agents/config/uv-previous-summary-catch22_test.ts
+++ b/agents/config/uv-previous-summary-catch22_test.ts
@@ -22,10 +22,14 @@
  * @module
  */
 
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { validateTemplateUvConsistency } from "./template-uv-validator.ts";
 import { validateUvReachability } from "./uv-reachability-validator.ts";
+import {
+  CONTINUATION_ONLY_UV_VARS,
+  RUNTIME_SUPPLIED_UV_VARS,
+} from "../shared/constants.ts";
 
 // =============================================================================
 // Helpers
@@ -351,5 +355,109 @@ Deno.test("Issue 07-d — catch-22 resolved: both configurations pass both valid
     );
   } finally {
     await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// =============================================================================
+// Test 5: Issue #453 — Rejection
+// Every CONTINUATION_ONLY_UV_VARS member must be rejected in initial.* steps
+// =============================================================================
+
+Deno.test("Issue #453 — non-vacuity: CONTINUATION_ONLY_UV_VARS is non-empty", () => {
+  // Guard: if the set is empty, all invariant tests below pass vacuously.
+  assert(
+    CONTINUATION_ONLY_UV_VARS.size > 0,
+    "CONTINUATION_ONLY_UV_VARS (agents/shared/constants.ts) must not be empty. " +
+      "If all members were removed, the phase-aware check in uv-reachability-validator.ts is dead code.",
+  );
+});
+
+Deno.test("Issue #453 — non-vacuity: CONTINUATION_ONLY_UV_VARS ⊂ RUNTIME_SUPPLIED_UV_VARS", () => {
+  // Every continuation-only var must be a member of the runtime-supplied set,
+  // otherwise the validator's Channel 2/3 branch never reaches the phase check.
+  for (const varName of CONTINUATION_ONLY_UV_VARS) {
+    assert(
+      RUNTIME_SUPPLIED_UV_VARS.has(varName),
+      `CONTINUATION_ONLY_UV_VARS member "${varName}" is not in RUNTIME_SUPPLIED_UV_VARS. ` +
+        `Fix: add "${varName}" to RUNTIME_SUPPLIED_UV_VARS in agents/shared/constants.ts, ` +
+        `or remove it from CONTINUATION_ONLY_UV_VARS.`,
+    );
+  }
+});
+
+Deno.test("Issue #453 — rejection: every CONTINUATION_ONLY_UV_VARS member rejected in initial.* step", () => {
+  // Invariant: for each continuation-only variable, declaring it in an
+  // initial.* step must produce exactly one error with actionable diagnosis.
+  // Source of truth: CONTINUATION_ONLY_UV_VARS from agents/shared/constants.ts
+  for (const varName of CONTINUATION_ONLY_UV_VARS) {
+    const registry = registryWith(`initial.test`, {
+      uvVariables: [varName],
+    });
+    const result = validateUvReachability(registry, agentWith({}));
+
+    assertEquals(
+      result.valid,
+      false,
+      `CONTINUATION_ONLY_UV_VARS member "${varName}" should be rejected in initial.* step. ` +
+        `Fix: add phase-aware check for "${varName}" in uv-reachability-validator.ts.`,
+    );
+    assertEquals(
+      result.errors.length,
+      1,
+      `Expected exactly 1 error for "${varName}" in initial.test, got ${result.errors.length}.`,
+    );
+    // Diagnosis: error message must contain What (var name + step), Where (steps_registry.json), How-to-fix
+    assertStringIncludes(result.errors[0], varName);
+    assertStringIncludes(result.errors[0], "continuation-only");
+    assertStringIncludes(result.errors[0], "PR-RESOLVE-003");
+    assertStringIncludes(result.errors[0], "steps_registry.json");
+  }
+});
+
+// =============================================================================
+// Test 6: Issue #453 — Acceptance
+// Continuation-only vars in continuation.* steps must pass;
+// always-available runtime vars in initial.* steps must pass
+// =============================================================================
+
+Deno.test("Issue #453 — acceptance: CONTINUATION_ONLY_UV_VARS accepted in continuation.* step", () => {
+  for (const varName of CONTINUATION_ONLY_UV_VARS) {
+    const registry = registryWith(`continuation.test`, {
+      uvVariables: [varName],
+    });
+    const result = validateUvReachability(registry, agentWith({}));
+
+    assertEquals(
+      result.valid,
+      true,
+      `"${varName}" should be accepted in continuation.* step.`,
+    );
+    assertEquals(result.errors.length, 0);
+  }
+});
+
+Deno.test("Issue #453 — acceptance: always-available runtime vars pass in initial.* step", () => {
+  // Runtime vars NOT in CONTINUATION_ONLY_UV_VARS should pass in initial.* steps.
+  const alwaysAvailable = [...RUNTIME_SUPPLIED_UV_VARS].filter(
+    (v) => !CONTINUATION_ONLY_UV_VARS.has(v),
+  );
+  assert(
+    alwaysAvailable.length > 0,
+    "No always-available runtime vars found — CONTINUATION_ONLY_UV_VARS equals RUNTIME_SUPPLIED_UV_VARS?",
+  );
+
+  for (const varName of alwaysAvailable) {
+    const registry = registryWith(`initial.test`, {
+      uvVariables: [varName],
+    });
+    const result = validateUvReachability(registry, agentWith({}));
+
+    assertEquals(
+      result.valid,
+      true,
+      `Runtime var "${varName}" is not continuation-only and should pass in initial.* step. ` +
+        `If this fails, "${varName}" was incorrectly added to CONTINUATION_ONLY_UV_VARS in agents/shared/constants.ts.`,
+    );
+    assertEquals(result.errors.length, 0);
   }
 });

--- a/agents/config/uv-reachability-validator.ts
+++ b/agents/config/uv-reachability-validator.ts
@@ -23,7 +23,10 @@
  */
 
 import type { ValidationResult } from "../src_common/types.ts";
-import { RUNTIME_SUPPLIED_UV_VARS } from "../shared/constants.ts";
+import {
+  CONTINUATION_ONLY_UV_VARS,
+  RUNTIME_SUPPLIED_UV_VARS,
+} from "../shared/constants.ts";
 import type { InputSpec } from "../src_common/contracts.ts";
 
 // ---------------------------------------------------------------------------
@@ -213,6 +216,19 @@ export function validateUvReachability(
 
       // Channel 2/3: Runtime-supplied variables
       if (RUNTIME_SUPPLIED_UV_VARS.has(varName)) {
+        // Phase-aware check: continuation-only variables in initial.* steps
+        // will cause PR-RESOLVE-003 at runtime (not set or falsy on iteration 1)
+        if (
+          stepId.startsWith(INITIAL_PREFIX) &&
+          CONTINUATION_ONLY_UV_VARS.has(varName)
+        ) {
+          errors.push(
+            `Step "${stepId}": UV variable "${varName}" is continuation-only (available from iteration 2+) ` +
+              `but declared in an initial.* step. This will cause PR-RESOLVE-003 at runtime. ` +
+              `Fix: remove "${varName}" from uvVariables in steps_registry.json for step "${stepId}", ` +
+              `or move it to the corresponding continuation.* step.`,
+          );
+        }
         continue;
       }
 

--- a/agents/orchestrator/orchestrator.ts
+++ b/agents/orchestrator/orchestrator.ts
@@ -134,6 +134,7 @@ export class Orchestrator {
 
     let finalPhase = "unknown";
     let status: OrchestratorResult["status"] = "blocked";
+    let issueClosed = false;
 
     // Each cycle depends on the previous: labels are read, agent dispatched,
     // labels updated, then re-read. Awaits must be sequential.
@@ -452,6 +453,44 @@ export class Orchestrator {
       if (targetPhaseDef) {
         if (targetPhaseDef.type === "terminal") {
           status = "completed";
+
+          // closeOnComplete: close the GitHub issue when agent outcome leads to terminal
+          if (!dryRun && agent.closeOnComplete) {
+            const shouldClose = agent.closeCondition === undefined ||
+              agent.closeCondition === dispatchResult.outcome;
+            if (shouldClose) {
+              try {
+                // deno-lint-ignore no-await-in-loop
+                await this.#github.closeIssue(issueNumber);
+                issueClosed = true;
+                // deno-lint-ignore no-await-in-loop
+                await log.info(
+                  `Closed issue #${issueNumber} (closeOnComplete, outcome="${dispatchResult.outcome}")`,
+                  {
+                    event: "issue_closed",
+                    issueNumber,
+                    agent: agentId,
+                    outcome: dispatchResult.outcome,
+                  },
+                );
+              } catch (error) {
+                const msg = error instanceof Error
+                  ? error.message
+                  : String(error);
+                // deno-lint-ignore no-await-in-loop
+                await log.warn(
+                  `Failed to close issue #${issueNumber}: ${msg}`,
+                  {
+                    event: "issue_close_failed",
+                    issueNumber,
+                    error: msg,
+                  },
+                );
+                // Non-fatal: label transition succeeded, close is best-effort
+              }
+            }
+          }
+
           break;
         }
         if (targetPhaseDef.type === "blocking") {
@@ -473,6 +512,7 @@ export class Orchestrator {
       cycleCount: tracker.getCount(issueNumber),
       history: tracker.getHistory(issueNumber),
       status,
+      ...(issueClosed ? { issueClosed } : {}),
     };
 
     await log.info(

--- a/agents/orchestrator/orchestrator_test.ts
+++ b/agents/orchestrator/orchestrator_test.ts
@@ -75,6 +75,8 @@ class StubGitHubClient implements GitHubClient {
     removed: string[];
     added: string[];
   }[] = [];
+  #closedIssues: number[] = [];
+  #closeIssueShouldThrow = false;
 
   constructor(labelSequence: string[][]) {
     this.#labelSequence = labelSequence;
@@ -129,8 +131,20 @@ class StubGitHubClient implements GitHubClient {
     return Promise.resolve(999);
   }
 
-  closeIssue(_issueNumber: number): Promise<void> {
+  closeIssue(issueNumber: number): Promise<void> {
+    if (this.#closeIssueShouldThrow) {
+      return Promise.reject(new Error("gh issue close failed"));
+    }
+    this.#closedIssues.push(issueNumber);
     return Promise.resolve();
+  }
+
+  get closedIssues(): number[] {
+    return this.#closedIssues;
+  }
+
+  setCloseIssueShouldThrow(v: boolean): void {
+    this.#closeIssueShouldThrow = v;
   }
 
   listIssues(_criteria: IssueCriteria): Promise<IssueListItem[]> {
@@ -484,6 +498,246 @@ Deno.test("full cycle with labelPrefix: prefixed labels resolve and transition c
   assertEquals(github.labelUpdates[0].added, ["wf:review"]);
   assertEquals(github.labelUpdates[1].removed, ["wf:review"]);
   assertEquals(github.labelUpdates[1].added, ["wf:done"]);
+});
+
+// === closeOnComplete Tests ===
+
+/**
+ * Test Design: Contract tests for closeOnComplete feature.
+ *
+ * Source of truth: orchestrator.ts terminal phase handling logic.
+ * The orchestrator calls closeIssue when:
+ *   1. target phase is terminal
+ *   2. !dryRun
+ *   3. agent.closeOnComplete === true
+ *   4. agent.closeCondition is undefined OR matches outcome
+ *
+ * Diagnosability: each assertion message identifies the violated contract
+ * and which file to fix (orchestrator.ts or workflow config).
+ */
+
+/** Config with closeOnComplete enabled on reviewer (validator) */
+function createCloseOnCompleteConfig(): WorkflowConfig {
+  return {
+    version: "1.0.0",
+    phases: {
+      implementation: { type: "actionable", priority: 1, agent: "iterator" },
+      review: { type: "actionable", priority: 2, agent: "reviewer" },
+      complete: { type: "terminal" },
+      blocked: { type: "blocking" },
+    },
+    labelMapping: {
+      ready: "implementation",
+      review: "review",
+      done: "complete",
+      blocked: "blocked",
+    },
+    agents: {
+      iterator: {
+        role: "transformer",
+        outputPhase: "review",
+        fallbackPhase: "blocked",
+      },
+      reviewer: {
+        role: "validator",
+        outputPhases: { approved: "complete", rejected: "implementation" },
+        fallbackPhase: "blocked",
+        closeOnComplete: true,
+        closeCondition: "approved",
+      },
+    },
+    rules: { maxCycles: 5, cycleDelayMs: 0 },
+  };
+}
+
+Deno.test("closeOnComplete: closes issue when outcome matches closeCondition and target is terminal", async () => {
+  const config = createCloseOnCompleteConfig();
+  // Cycle 1: iterator success -> review
+  // Cycle 2: reviewer approved -> complete (terminal) -> closeIssue
+  const github = new StubGitHubClient([["ready"], ["review"], ["done"]]);
+  const dispatcher = new StubDispatcher({
+    iterator: "success",
+    reviewer: "approved",
+  });
+  const orchestrator = new Orchestrator(config, github, dispatcher);
+
+  const result = await orchestrator.run(1);
+
+  assertEquals(
+    result.status,
+    "completed",
+    "Status should be completed. Fix: orchestrator.ts terminal phase handling",
+  );
+  assertEquals(
+    result.issueClosed,
+    true,
+    "issueClosed should be true when closeOnComplete fires. Fix: orchestrator.ts closeOnComplete logic",
+  );
+  assertEquals(
+    github.closedIssues.length,
+    1,
+    "closeIssue should be called exactly once. Fix: orchestrator.ts closeOnComplete logic",
+  );
+  assertEquals(
+    github.closedIssues[0],
+    1,
+    "closeIssue should receive the correct issue number",
+  );
+});
+
+Deno.test("closeOnComplete: does NOT close when outcome does not match closeCondition", async () => {
+  const config = createCloseOnCompleteConfig();
+  // reviewer rejects -> goes to implementation (not terminal) -> no close
+  const github = new StubGitHubClient([["review"], ["ready"], ["ready"]]);
+  const dispatcher = new StubDispatcher({
+    iterator: "success",
+    reviewer: "rejected",
+  });
+  config.rules.maxCycles = 2;
+  const orchestrator = new Orchestrator(config, github, dispatcher);
+
+  const result = await orchestrator.run(1);
+
+  assertEquals(
+    github.closedIssues.length,
+    0,
+    "closeIssue should not be called when outcome doesn't lead to terminal. " +
+      "Fix: orchestrator.ts closeCondition check",
+  );
+  assertEquals(
+    result.issueClosed,
+    undefined,
+    "issueClosed should be undefined when close was not triggered",
+  );
+});
+
+Deno.test("closeOnComplete: closes without closeCondition (any terminal outcome)", async () => {
+  const config = createCloseOnCompleteConfig();
+  // Remove closeCondition -> any terminal transition triggers close
+  delete (config.agents["reviewer"] as unknown as Record<string, unknown>)
+    .closeCondition;
+
+  const github = new StubGitHubClient([["ready"], ["review"], ["done"]]);
+  const dispatcher = new StubDispatcher({
+    iterator: "success",
+    reviewer: "approved",
+  });
+  const orchestrator = new Orchestrator(config, github, dispatcher);
+
+  const result = await orchestrator.run(1);
+
+  assertEquals(result.issueClosed, true);
+  assertEquals(github.closedIssues.length, 1);
+});
+
+Deno.test("closeOnComplete: does NOT close when closeOnComplete is absent", async () => {
+  const config = createTestConfig(); // no closeOnComplete
+  const github = new StubGitHubClient([["ready"], ["review"], ["done"]]);
+  const dispatcher = new StubDispatcher({
+    iterator: "success",
+    reviewer: "approved",
+  });
+  const orchestrator = new Orchestrator(config, github, dispatcher);
+
+  const result = await orchestrator.run(1);
+
+  assertEquals(result.status, "completed");
+  assertEquals(
+    github.closedIssues.length,
+    0,
+    "closeIssue should not be called when closeOnComplete is not set. " +
+      "Fix: orchestrator.ts should only close when agent.closeOnComplete is true",
+  );
+  assertEquals(result.issueClosed, undefined);
+});
+
+Deno.test("closeOnComplete: early terminal detection does NOT trigger close", async () => {
+  const config = createCloseOnCompleteConfig();
+  // Issue starts with terminal labels -> no agent dispatched -> no close
+  const github = new StubGitHubClient([["done"]]);
+  const dispatcher = new StubDispatcher();
+  const orchestrator = new Orchestrator(config, github, dispatcher);
+
+  const result = await orchestrator.run(1);
+
+  assertEquals(result.status, "completed");
+  assertEquals(
+    github.closedIssues.length,
+    0,
+    "Early terminal detection should not trigger close (no agent dispatched). " +
+      "Fix: orchestrator.ts should only close after agent dispatch, not at early terminal check",
+  );
+  assertEquals(result.issueClosed, undefined);
+});
+
+Deno.test("closeOnComplete: closeIssue failure is non-fatal", async () => {
+  const config = createCloseOnCompleteConfig();
+  const github = new StubGitHubClient([["ready"], ["review"], ["done"]]);
+  github.setCloseIssueShouldThrow(true);
+  const dispatcher = new StubDispatcher({
+    iterator: "success",
+    reviewer: "approved",
+  });
+  const orchestrator = new Orchestrator(config, github, dispatcher);
+
+  const result = await orchestrator.run(1);
+
+  assertEquals(
+    result.status,
+    "completed",
+    "Workflow should complete even if closeIssue fails. " +
+      "Fix: orchestrator.ts closeOnComplete error must be non-fatal",
+  );
+  assertEquals(
+    result.issueClosed,
+    undefined,
+    "issueClosed should not be true when closeIssue threw",
+  );
+  assertEquals(github.closedIssues.length, 0);
+});
+
+Deno.test("closeOnComplete: closeCondition filters even when target is terminal", async () => {
+  // Validator where both outcomes route to terminal, but closeCondition is "approved"
+  const config: WorkflowConfig = {
+    version: "1.0.0",
+    phases: {
+      review: { type: "actionable", priority: 1, agent: "reviewer" },
+      closed: { type: "terminal" },
+      archived: { type: "terminal" },
+    },
+    labelMapping: {
+      review: "review",
+      done: "closed",
+      archive: "archived",
+    },
+    agents: {
+      reviewer: {
+        role: "validator",
+        outputPhases: { approved: "closed", auto_closed: "archived" },
+        fallbackPhase: "review",
+        closeOnComplete: true,
+        closeCondition: "approved",
+      },
+    },
+    rules: { maxCycles: 5, cycleDelayMs: 0 },
+  };
+
+  // outcome is "auto_closed" -> routes to terminal "archived" but closeCondition is "approved"
+  const github = new StubGitHubClient([["review"], ["archive"]]);
+  const dispatcher = new StubDispatcher({ reviewer: "auto_closed" });
+  const orchestrator = new Orchestrator(config, github, dispatcher);
+
+  const result = await orchestrator.run(1);
+
+  assertEquals(result.status, "completed");
+  assertEquals(result.finalPhase, "archived");
+  assertEquals(
+    github.closedIssues.length,
+    0,
+    "closeIssue should NOT be called when outcome is 'auto_closed' but closeCondition is 'approved'. " +
+      "Fix: orchestrator.ts must check closeCondition against outcome, not just terminal phase",
+  );
+  assertEquals(result.issueClosed, undefined);
 });
 
 // === Batch Tests ===

--- a/agents/orchestrator/workflow-loader.ts
+++ b/agents/orchestrator/workflow-loader.ts
@@ -22,6 +22,8 @@ import {
   wfPhaseAgentRequired,
   wfPhaseInvalidType,
   wfPhasePriorityRequired,
+  wfRefCloseConditionWithoutCloseOnComplete,
+  wfRefInvalidCloseCondition,
   wfRefUnknownAgent,
   wfRefUnknownFallbackPhase,
   wfRefUnknownOutputPhase,
@@ -203,6 +205,23 @@ function validateAgentPhaseReferences(
       if (!phaseIds.has(targetPhase)) {
         throw wfRefUnknownOutputPhasesEntry(agentId, key, targetPhase);
       }
+    }
+  }
+
+  // closeCondition cross-validation
+  if (agent.closeCondition !== undefined) {
+    if (!agent.closeOnComplete) {
+      throw wfRefCloseConditionWithoutCloseOnComplete(agentId);
+    }
+    if (
+      agent.role === "validator" &&
+      !(agent.closeCondition in agent.outputPhases)
+    ) {
+      throw wfRefInvalidCloseCondition(
+        agentId,
+        agent.closeCondition,
+        Object.keys(agent.outputPhases),
+      );
     }
   }
 }

--- a/agents/orchestrator/workflow-loader_test.ts
+++ b/agents/orchestrator/workflow-loader_test.ts
@@ -326,6 +326,114 @@ Deno.test("workflow-loader: labelPrefix field is parsed", async () => {
   }
 });
 
+// =============================================================================
+// Cross-reference: closeCondition validation
+// =============================================================================
+
+Deno.test("workflow-loader: closeCondition without closeOnComplete throws WF-REF-005", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const cfg = validConfig();
+    (cfg.agents as Record<string, unknown>)["reviewer"] = {
+      role: "validator",
+      outputPhases: { approved: "complete", rejected: "implementation" },
+      fallbackPhase: "blocked",
+      closeCondition: "approved", // no closeOnComplete
+    };
+    await writeFixture(dir, cfg);
+    const err = await assertRejects(
+      () => loadWorkflow(dir),
+      Error,
+    );
+    assertStringIncludes(
+      err.message,
+      "reviewer",
+      "Error should name the agent. Fix: config-errors.ts wfRefCloseConditionWithoutCloseOnComplete",
+    );
+    assertStringIncludes(
+      err.message,
+      "closeOnComplete",
+      "Error should mention closeOnComplete. Fix: config-errors.ts WF-REF-005",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: closeCondition with unknown outcome key throws WF-REF-006", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const cfg = validConfig();
+    (cfg.agents as Record<string, unknown>)["reviewer"] = {
+      role: "validator",
+      outputPhases: { approved: "complete", rejected: "implementation" },
+      fallbackPhase: "blocked",
+      closeOnComplete: true,
+      closeCondition: "typo_approved", // not in outputPhases
+    };
+    await writeFixture(dir, cfg);
+    const err = await assertRejects(
+      () => loadWorkflow(dir),
+      Error,
+    );
+    assertStringIncludes(
+      err.message,
+      "reviewer",
+      "Error should name the agent. Fix: config-errors.ts wfRefInvalidCloseCondition",
+    );
+    assertStringIncludes(
+      err.message,
+      "typo_approved",
+      "Error should include the invalid closeCondition value. Fix: config-errors.ts WF-REF-006",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: valid closeOnComplete and closeCondition loads successfully", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const cfg = validConfig();
+    (cfg.agents as Record<string, unknown>)["reviewer"] = {
+      role: "validator",
+      outputPhases: { approved: "complete", rejected: "implementation" },
+      fallbackPhase: "blocked",
+      closeOnComplete: true,
+      closeCondition: "approved",
+    };
+    await writeFixture(dir, cfg);
+    const config = await loadWorkflow(dir);
+    assertEquals(config.agents["reviewer"].closeOnComplete, true);
+    assertEquals(config.agents["reviewer"].closeCondition, "approved");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: closeOnComplete without closeCondition loads successfully", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const cfg = validConfig();
+    (cfg.agents as Record<string, unknown>)["reviewer"] = {
+      role: "validator",
+      outputPhases: { approved: "complete", rejected: "implementation" },
+      fallbackPhase: "blocked",
+      closeOnComplete: true,
+    };
+    await writeFixture(dir, cfg);
+    const config = await loadWorkflow(dir);
+    assertEquals(config.agents["reviewer"].closeOnComplete, true);
+    assertEquals(config.agents["reviewer"].closeCondition, undefined);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// =============================================================================
+// labelPrefix
+// =============================================================================
+
 Deno.test("workflow-loader: labelPrefix is undefined when omitted", async () => {
   const dir = await Deno.makeTempDir();
   try {

--- a/agents/orchestrator/workflow-schema.json
+++ b/agents/orchestrator/workflow-schema.json
@@ -66,6 +66,14 @@
             "type": "string",
             "description": "Phase to transition to on error"
           },
+          "closeOnComplete": {
+            "type": "boolean",
+            "description": "Close the GitHub issue when this agent's outcome leads to a terminal phase"
+          },
+          "closeCondition": {
+            "type": "string",
+            "description": "Only close the issue when the outcome matches this value (requires closeOnComplete: true)"
+          },
           "outputPhase": {
             "type": "string",
             "description": "Phase to transition to on successful completion (transformer only)"

--- a/agents/orchestrator/workflow-types.ts
+++ b/agents/orchestrator/workflow-types.ts
@@ -39,6 +39,16 @@ export interface BaseAgentDefinition {
 
   /** Phase to transition to on error */
   fallbackPhase?: string;
+
+  /** Close the GitHub issue when this agent's outcome leads to a terminal phase */
+  closeOnComplete?: boolean;
+
+  /**
+   * Only close the issue when the outcome matches this value.
+   * Requires closeOnComplete: true. Useful for validators that route
+   * to different terminal phases (e.g., close only on "approved").
+   */
+  closeCondition?: string;
 }
 
 /** Agent that produces a single output phase on success */
@@ -162,6 +172,8 @@ export interface OrchestratorResult {
   cycleCount: number;
   history: PhaseTransitionRecord[];
   status: "completed" | "blocked" | "cycle_exceeded" | "dry-run";
+  /** True when closeOnComplete triggered and gh issue close succeeded */
+  issueClosed?: boolean;
 }
 
 /** Options for batch orchestrator execution. */

--- a/agents/runner/runner-loop-integration_test.ts
+++ b/agents/runner/runner-loop-integration_test.ts
@@ -126,6 +126,7 @@ function createMockVerdictHandler(
       return Promise.resolve(val);
     },
     getVerdictDescription: () => Promise.resolve(desc),
+    getLastVerdict: () => undefined,
     setCurrentSummary: () => {},
   };
 }
@@ -552,6 +553,7 @@ function createCapturingVerdictHandler(): VerdictHandler & {
     }),
     isFinished: () => Promise.resolve(true), // finish after 1 iteration
     getVerdictDescription: () => Promise.resolve("Test verdict"),
+    getLastVerdict: () => undefined,
     setCurrentSummary: (summary: IterationSummary) => {
       captured.push(summary);
     },
@@ -661,7 +663,7 @@ function createVerdictProvidingHandler(verdict: string): VerdictHandler {
     getVerdictDescription: () => Promise.resolve("Verdict provided"),
     setCurrentSummary: () => {},
     getLastVerdict: () => verdict,
-  } as VerdictHandler & { getLastVerdict: () => string };
+  };
 }
 
 Deno.test("AgentRunner.run - getLastVerdict propagates to AgentResult.verdict", async () => {

--- a/agents/runner/runner.ts
+++ b/agents/runner/runner.ts
@@ -723,11 +723,8 @@ export class AgentRunner {
         }
       }
 
-      // Extract verdict from verdict handler if available (e.g., ExternalStateVerdictAdapter)
-      const verdictValue = "getLastVerdict" in ctx.verdictHandler &&
-          typeof ctx.verdictHandler.getLastVerdict === "function"
-        ? (ctx.verdictHandler.getLastVerdict as () => string | undefined)()
-        : undefined;
+      // Extract verdict from verdict handler for orchestrator routing
+      const verdictValue = ctx.verdictHandler.getLastVerdict();
 
       const result: AgentResult = {
         success,

--- a/agents/shared/constants.ts
+++ b/agents/shared/constants.ts
@@ -97,3 +97,20 @@ export const RUNTIME_SUPPLIED_UV_VARS = new Set([
   "check_count",
   "max_checks",
 ]) as ReadonlySet<string>;
+
+/**
+ * Subset of RUNTIME_SUPPLIED_UV_VARS that are only available on continuation
+ * iterations (iteration > 1). Declaring these in initial.* steps will cause
+ * PR-RESOLVE-003 at runtime because:
+ *
+ * - completed_iterations: Not set at all on iteration 1
+ *   (buildUvVariables guards with `if (iteration > 1)`)
+ * - previous_summary: Set to "" on iteration 1, but prompt-resolver treats
+ *   falsy values as missing (`!variables.uv?.[key]`)
+ *
+ * Used by uv-reachability-validator.ts to emit errors for initial.* steps.
+ */
+export const CONTINUATION_ONLY_UV_VARS = new Set([
+  "completed_iterations",
+  "previous_summary",
+]) as ReadonlySet<string>;

--- a/agents/shared/errors/config-errors.ts
+++ b/agents/shared/errors/config-errors.ts
@@ -589,6 +589,38 @@ export function wfRefUnknownOutputPhasesEntry(
   );
 }
 
+// --- WF-REF: closeOnComplete / closeCondition cross-reference errors ---
+
+export function wfRefCloseConditionWithoutCloseOnComplete(
+  agentId: string,
+): ConfigError {
+  return new ConfigError(
+    "WF-REF-005",
+    `Agent "${agentId}" has "closeCondition" but "closeOnComplete" is not enabled.`,
+    `"closeCondition" filters which outcome triggers issue close, so it requires "closeOnComplete: true" to take effect.`,
+    `Add "closeOnComplete": true to agent "${agentId}", or remove "closeCondition".`,
+    "workflow.json",
+  );
+}
+
+export function wfRefInvalidCloseCondition(
+  agentId: string,
+  closeCondition: string,
+  validKeys: string[],
+): ConfigError {
+  return new ConfigError(
+    "WF-REF-006",
+    `Agent "${agentId}" closeCondition "${closeCondition}" is not a key in outputPhases.`,
+    `closeCondition must match one of the outcome keys in outputPhases so it can actually trigger. Valid keys: [${
+      validKeys.join(", ")
+    }].`,
+    `Change closeCondition to one of [${
+      validKeys.join(", ")
+    }], or add "${closeCondition}" to outputPhases.`,
+    "workflow.json",
+  );
+}
+
 // --- WF-BATCH: Batch operation errors ---
 
 export function wfBatchPrioritizeMissingConfig(): ConfigError {

--- a/agents/shared/errors/mod.ts
+++ b/agents/shared/errors/mod.ts
@@ -127,6 +127,8 @@ export {
   wfPhaseAgentRequired,
   wfPhaseInvalidType,
   wfPhasePriorityRequired,
+  wfRefCloseConditionWithoutCloseOnComplete,
+  wfRefInvalidCloseCondition,
   wfRefUnknownAgent,
   wfRefUnknownFallbackPhase,
   wfRefUnknownOutputPhase,

--- a/agents/verdict/external-state-adapter.ts
+++ b/agents/verdict/external-state-adapter.ts
@@ -75,7 +75,7 @@ export class ExternalStateVerdictAdapter extends BaseVerdictHandler {
    * Get the last verdict value extracted from AI structured output.
    * Returns undefined if no verdict has been received yet.
    */
-  getLastVerdict(): string | undefined {
+  override getLastVerdict(): string | undefined {
     return this.#lastVerdict;
   }
 

--- a/agents/verdict/step-machine-verdict_test.ts
+++ b/agents/verdict/step-machine-verdict_test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for Issue #454
+ *
+ * StepMachineVerdictHandler verdict extraction for orchestrator routing.
+ *
+ * When a detect:graph agent's closure step produces structured output with a
+ * `verdict` field, the handler must expose it via getLastVerdict() so the
+ * runner can populate AgentResult.verdict and the orchestrator can route
+ * via outputPhases.
+ *
+ * @module
+ */
+
+import { assertEquals } from "@std/assert";
+import { StepMachineVerdictHandler } from "./step-machine.ts";
+import type { ExtendedStepsRegistry } from "../common/validation-types.ts";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createMinimalRegistry(
+  entryStep = "initial.review",
+): ExtendedStepsRegistry {
+  return {
+    agentId: "test",
+    version: "1.0.0",
+    c1: "steps",
+    entryStep,
+    steps: {
+      [entryStep]: {
+        name: "Test Step",
+        c2: "initial",
+        c3: "review",
+        edition: "default",
+      },
+    },
+  } as ExtendedStepsRegistry;
+}
+
+function createHandler(
+  entryStep = "initial.review",
+): StepMachineVerdictHandler {
+  return new StepMachineVerdictHandler(
+    createMinimalRegistry(entryStep),
+    entryStep,
+  );
+}
+
+// =============================================================================
+// Verdict extraction via onBoundaryHook
+// =============================================================================
+
+Deno.test("StepMachine - onBoundaryHook extracts verdict from structured output", async () => {
+  const handler = createHandler();
+
+  await handler.onBoundaryHook({
+    stepId: "closure.review",
+    stepKind: "closure",
+    structuredOutput: {
+      verdict: "approved",
+      closure_action: "label-and-close",
+    },
+  });
+
+  assertEquals(handler.getLastVerdict(), "approved");
+});
+
+Deno.test("StepMachine - onBoundaryHook extracts rejected verdict", async () => {
+  const handler = createHandler();
+
+  await handler.onBoundaryHook({
+    stepId: "closure.review",
+    stepKind: "closure",
+    structuredOutput: {
+      verdict: "rejected",
+      closure_action: "label-only",
+    },
+  });
+
+  assertEquals(handler.getLastVerdict(), "rejected");
+});
+
+Deno.test("StepMachine - getLastVerdict returns undefined before onBoundaryHook", () => {
+  const handler = createHandler();
+  assertEquals(handler.getLastVerdict(), undefined);
+});
+
+Deno.test("StepMachine - onBoundaryHook ignores missing verdict field", async () => {
+  const handler = createHandler();
+
+  await handler.onBoundaryHook({
+    stepId: "closure.review",
+    stepKind: "closure",
+    structuredOutput: { closure_action: "close" },
+  });
+
+  assertEquals(handler.getLastVerdict(), undefined);
+});
+
+Deno.test("StepMachine - onBoundaryHook ignores non-string verdict", async () => {
+  const handler = createHandler();
+
+  await handler.onBoundaryHook({
+    stepId: "closure.review",
+    stepKind: "closure",
+    structuredOutput: { verdict: 123 },
+  });
+
+  assertEquals(handler.getLastVerdict(), undefined);
+});
+
+Deno.test("StepMachine - onBoundaryHook ignores empty string verdict", async () => {
+  const handler = createHandler();
+
+  await handler.onBoundaryHook({
+    stepId: "closure.review",
+    stepKind: "closure",
+    structuredOutput: { verdict: "" },
+  });
+
+  assertEquals(handler.getLastVerdict(), undefined);
+});
+
+Deno.test("StepMachine - onBoundaryHook without structuredOutput is no-op", async () => {
+  const handler = createHandler();
+
+  await handler.onBoundaryHook({
+    stepId: "closure.review",
+    stepKind: "closure",
+  });
+
+  assertEquals(handler.getLastVerdict(), undefined);
+});
+
+Deno.test("StepMachine - getLastVerdict returns latest verdict on multiple calls", async () => {
+  const handler = createHandler();
+
+  await handler.onBoundaryHook({
+    stepId: "closure.review",
+    stepKind: "closure",
+    structuredOutput: { verdict: "approved" },
+  });
+  assertEquals(handler.getLastVerdict(), "approved");
+
+  await handler.onBoundaryHook({
+    stepId: "closure.review",
+    stepKind: "closure",
+    structuredOutput: { verdict: "rejected" },
+  });
+  assertEquals(handler.getLastVerdict(), "rejected");
+});

--- a/agents/verdict/step-machine.ts
+++ b/agents/verdict/step-machine.ts
@@ -52,6 +52,7 @@ export class StepMachineVerdictHandler extends BaseVerdictHandler {
   private state: StepState;
   private verdictReason?: string;
   private lastSummary?: IterationSummary;
+  #lastVerdict?: string;
 
   constructor(
     private readonly registry: ExtendedStepsRegistry,
@@ -88,6 +89,14 @@ export class StepMachineVerdictHandler extends BaseVerdictHandler {
    */
   setUvVariables(uv: Record<string, string>): void {
     this.uvVariables = uv;
+  }
+
+  /**
+   * Get the last verdict value extracted from closure step's structured output.
+   * Used by runner to populate AgentResult.verdict for orchestrator routing.
+   */
+  override getLastVerdict(): string | undefined {
+    return this.#lastVerdict;
   }
 
   /**
@@ -249,6 +258,24 @@ ${this.buildStepInstructions(stepDef, this.state.currentStepId)}
         `The task is complete when the step machine reaches a terminal state. ` +
         `Current step: ${this.state.currentStepId}`,
     };
+  }
+
+  /**
+   * Handle boundary hook for closure steps.
+   * Extracts verdict from structured output for orchestrator routing.
+   */
+  onBoundaryHook(payload: {
+    stepId: string;
+    stepKind: "closure";
+    structuredOutput?: Record<string, unknown>;
+  }): Promise<void> {
+    if (payload.structuredOutput) {
+      const rawVerdict = payload.structuredOutput.verdict;
+      if (typeof rawVerdict === "string" && rawVerdict.length > 0) {
+        this.#lastVerdict = rawVerdict;
+      }
+    }
+    return Promise.resolve();
   }
 
   isFinished(): Promise<boolean> {

--- a/agents/verdict/types.ts
+++ b/agents/verdict/types.ts
@@ -160,6 +160,13 @@ export interface VerdictHandler {
   getVerdictDescription(): Promise<string>;
 
   /**
+   * Get the last verdict value extracted from structured output.
+   * Used by runner to populate AgentResult.verdict for orchestrator routing.
+   * Default: returns undefined (no verdict).
+   */
+  getLastVerdict(): string | undefined;
+
+  /**
    * Called when a closure step emits `closing` intent.
    *
    * This is the single surface for external side effects:
@@ -192,6 +199,14 @@ export abstract class BaseVerdictHandler implements VerdictHandler {
   abstract buildVerdictCriteria(): VerdictCriteria;
   abstract isFinished(): Promise<boolean>;
   abstract getVerdictDescription(): Promise<string>;
+
+  /**
+   * Default: no verdict. Override in handlers that extract verdict from
+   * structured output (e.g., detect:graph, poll:state).
+   */
+  getLastVerdict(): string | undefined {
+    return undefined;
+  }
 
   /**
    * Format iteration summary for continuation prompts

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.13.21",
+  "version": "1.13.22",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.13.21",
+  "version": "1.13.22",
   "entries": [
     {
       "id": "builder-01_quickstart",
@@ -27,7 +27,7 @@
       "path": "../agents/docs/builder/04_config_system.md",
       "category": "builder-guides",
       "title": "設定システム",
-      "bytes": 3479
+      "bytes": 5764
     },
     {
       "id": "builder-05_troubleshooting",
@@ -41,7 +41,7 @@
       "path": "../agents/docs/builder/06_workflow_setup.md",
       "category": "builder-guides",
       "title": "Workflow Setup",
-      "bytes": 13421
+      "bytes": 13511
     },
     {
       "id": "builder-07_github_integration",
@@ -55,7 +55,7 @@
       "path": "../agents/docs/builder/08_closure_output_contract.md",
       "category": "builder-guides",
       "title": "Closure Output Contract",
-      "bytes": 10878
+      "bytes": 10943
     },
     {
       "id": "builder-README",
@@ -232,7 +232,7 @@
       "category": "guides",
       "lang": "en",
       "title": "Workflow Guide",
-      "bytes": 11887
+      "bytes": 13906
     },
     {
       "id": "guides-ja-00-1-concepts",
@@ -368,7 +368,7 @@
       "category": "guides",
       "lang": "ja",
       "title": "ワークフローガイド",
-      "bytes": 13007
+      "bytes": 15196
     },
     {
       "id": "mcp-setup",

--- a/examples/45_verify_factory_completionpath/fixtures/custom-handler.ts
+++ b/examples/45_verify_factory_completionpath/fixtures/custom-handler.ts
@@ -42,6 +42,10 @@ class TestCustomVerdictHandler implements VerdictHandler {
   getVerdictDescription(): Promise<string> {
     return Promise.resolve("Custom handler - not finished");
   }
+
+  getLastVerdict(): string | undefined {
+    return undefined;
+  }
 }
 
 /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.13.21";
+export const CLIMPT_VERSION = "1.13.22";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
- feat: implement closeOnComplete for orchestrator terminal phases (#455)
- fix: route detect:graph verdict to orchestrator outputPhases (#454)
- fix: detect continuation-only UV variables in initial.* steps (#453)
- refactor: promote getLastVerdict to VerdictHandler interface

## Test plan
- [x] Local CI: 1415 tests passed
- [x] E2E: 50/54 passed (4 SDK-only infra failures)
- [x] Remote CI on develop PR: passed
- [ ] Remote CI on main PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)