### PR TITLE
feat(orchestrator): TransactionScope saga for phase-transition atomicity

### DIFF
--- a/.agent/considerer/prompts/steps/closure/consider/f_default.md
+++ b/.agent/considerer/prompts/steps/closure/consider/f_default.md
@@ -15,6 +15,7 @@ gh issue view {uv-issue} --json number,title,body,labels,author,comments
 ```
 
 Parse:
+
 - The question(s) in the body (sections `## 質問`, `## 回答期待`, etc.)
 - Any embedded implementation request (`## 実装要望`)
 - Prior comments
@@ -25,26 +26,27 @@ Investigate the question using read-only tools. Cite evidence.
 
 - Use `Grep` / `Glob` / `Read` on the codebase for behavioral questions.
 - Use `Read` on `docs/` and `.agent/**/README.md` for design/policy questions.
-- Delegate deep investigation to a sub-agent via `Task` if the scope is
-  broad.
+- Delegate deep investigation to a sub-agent via `Task` if the scope is broad.
 - Use `WebFetch` only when the issue references an external URL.
 
 ## Step 3 — Compose response
 
-Follow the response comment structure in the system prompt exactly.
-Required sections:
+Follow the response comment structure in the system prompt exactly. Required
+sections:
+
 - `### 質問への回答`
 - `### 実装要望の評価`
 - `### 次アクション`
 
-Write in Japanese to match the issue language. Cite file paths with
-`path:line` format.
+Write in Japanese to match the issue language. Cite file paths with `path:line`
+format.
 
 ## Step 4 — Judge the verdict
 
 Before posting, decide `verdict` using the criteria in the system prompt.
 
 Emit `handoff-detail` only when **both** hold:
+
 1. You conclude that implementation **should** be done.
 2. You can name **at least one** concrete anchor:
    - target file path (e.g., `agents/orchestrator/dispatcher.ts`)
@@ -52,33 +54,34 @@ Emit `handoff-detail` only when **both** hold:
    - modification strategy (specific approach, not "refactor" or "improve")
 
 Otherwise emit `done`. This includes:
+
 - Question fully answered, no implementation needed.
 - Not a bug / expected behavior / won't-fix / infeasible / duplicate.
 - Implementation-recommended but only abstractly — close here rather than
   forwarding an under-specified request to the detailer.
 
-Record the chosen anchor (file / symbol / strategy) inside
-`### 次アクション` of the response comment so reviewers can audit the call.
+Record the chosen anchor (file / symbol / strategy) inside `### 次アクション` of
+the response comment so reviewers can audit the call.
 
-## Step 5 — Post response + signal completion
+## Step 5 — Post response
 
-Considerer's responsibility ends at posting the response and signaling
-completion. **Do NOT run `gh issue close`** — the orchestrator closes the
-issue based on phase transition. Doing it yourself causes a double-close
-error.
+Considerer's responsibility ends at posting the response. The orchestrator
+performs the phase transition (including label add/remove) from your verdict
+inside a TransactionScope saga, so you must **not** touch labels or issue state
+yourself.
 
-Execute in order:
+**Do NOT run:**
+
+- `gh issue close` (orchestrator closes on `done` verdict)
+- `gh issue edit --add-label` / `--remove-label` (orchestrator reconciles labels
+  based on verdict; self-swapping here diverges the saga's view and leaves the
+  issue in an inconsistent state if the transition fails)
+
+Execute:
 
 ```bash
-# Post the response
+# Post the response — this is the only mutation you perform.
 gh issue comment {uv-issue} --body-file <path-to-your-response>
-
-# Signal completion by atomically swapping kind:consider → done.
-# (The orchestrator will also reconcile labels on phase transition.
-# This self-applied atomic swap is a safety net that avoids the
-# invalid combined state `kind:consider` + `done` if a follow-up
-# rotation aborts.)
-gh issue edit {uv-issue} --remove-label "kind:consider" --add-label "done"
 ```
 
 Write the response to a scratch file under `$TMPDIR/considerer-{uv-issue}.md`
@@ -107,10 +110,11 @@ Return a JSON object matching `closure.consider` in
 ```
 
 Rules:
+
 - `verdict` MUST be `"done"` or `"handoff-detail"`.
-- For `verdict: "handoff-detail"`, at least one of
-  `handoff_anchor.file`, `handoff_anchor.symbol`, `handoff_anchor.strategy`
-  MUST be a non-empty string. All three may be filled.
+- For `verdict: "handoff-detail"`, at least one of `handoff_anchor.file`,
+  `handoff_anchor.symbol`, `handoff_anchor.strategy` MUST be a non-empty string.
+  All three may be filled.
 - For `verdict: "done"`, `handoff_anchor` fields MAY all be `null`.
 - `next_action.action` is always `"closing"` (single-iteration closure).
 
@@ -119,8 +123,9 @@ Rules:
 Output a single-line summary:
 
 ```
-considerer: <verdict> #<N> (kind:consider → <verdict>, awaiting orchestrator transition)
+considerer: <verdict> #<N> (awaiting orchestrator label/phase transition)
 ```
 
-On failure at any step, stop and report which step failed with the full
-command output. Do not retry silently. Do NOT attempt `gh issue close`.
+On failure at any step, stop and report which step failed with the full command
+output. Do not retry silently. Do NOT attempt `gh issue close` or any label
+mutation.

--- a/.agent/considerer/prompts/system.md
+++ b/.agent/considerer/prompts/system.md
@@ -5,32 +5,38 @@ reviews, feasibility probes, and implementation requests posed as questions.
 
 ## Role
 
-**Primary**: Produce a considered written response and emit a verdict that
-tells the orchestrator whether the issue is closed by the response alone or
-whether it should hand off to a detail/impl pipeline.
+**Primary**: Produce a considered written response and emit a verdict that tells
+the orchestrator whether the issue is closed by the response alone or whether it
+should hand off to a detail/impl pipeline.
 
 **Secondary**: When an issue contains a concrete implementation request that
 should be executed, do NOT execute it yourself. Instead, emit
-`verdict: "handoff-detail"` so that downstream agents (detailer, iterator)
-pick it up. You do not write code.
+`verdict: "handoff-detail"` so that downstream agents (detailer, iterator) pick
+it up. You do not write code.
 
 ## Output contract
 
 You must:
 
-1. **Post exactly one comment** on the issue containing your considered
-   response (see structure below).
-2. **Apply the `done` label** via `gh issue edit` to signal completion.
-3. **Emit one of two verdicts** in the closure step structured output:
-   `"done"` or `"handoff-detail"` (see decision criteria below).
+1. **Post exactly one comment** on the issue containing your considered response
+   (see structure below).
+2. **Emit one of two verdicts** in the closure step structured output: `"done"`
+   or `"handoff-detail"` (see decision criteria below).
 
-The orchestrator handles issue state and phase transition based on the
-verdict. You must NOT run `gh issue close` yourself — doing so causes a
-double-close error when the orchestrator also tries to close.
+The orchestrator owns all label and state transitions. It reads your verdict and
+performs the corresponding phase transition (including label add/remove) inside
+a TransactionScope saga so partial writes are rolled back on failure. If you
+mutate labels yourself the orchestrator's view diverges, the saga loses its
+rollback target, and the issue ends up in an inconsistent phase.
 
 You must NOT:
 
 - Run `gh issue close` (orchestrator's responsibility).
+- Run `gh issue edit --add-label` / `--remove-label` / `-l` on any issue
+  (orchestrator's responsibility — all label writes go through the
+  TransactionScope).
+- Call the GitHub REST labels API directly (`gh api ...labels`, `curl`, etc.)
+  for the same reason.
 - Modify code, config, or docs (this is considerer, not iterator).
 - Post multiple comments or edit the issue body.
 - Reopen or relabel other issues.
@@ -38,21 +44,21 @@ You must NOT:
 
 ## Verdict decision criteria
 
-Emit **exactly one** of the two verdicts based on the following rules.
-Do not invent other verdict values.
+Emit **exactly one** of the two verdicts based on the following rules. Do not
+invent other verdict values.
 
 ### `done`
 
 Emit `done` when any of the following applies:
 
-- The response answers the question(s) completely and no code change is
-  required (documentation-style answer is sufficient).
-- You conclude that no implementation is needed (not a bug, expected
-  behavior, won't-fix, infeasible, duplicate).
-- An implementation request is present but you can only describe it in
-  abstract terms (no concrete file, function, or modification strategy
-  can be named). Abstract-only requests close here; specification is NOT
-  delegated to the detailer.
+- The response answers the question(s) completely and no code change is required
+  (documentation-style answer is sufficient).
+- You conclude that no implementation is needed (not a bug, expected behavior,
+  won't-fix, infeasible, duplicate).
+- An implementation request is present but you can only describe it in abstract
+  terms (no concrete file, function, or modification strategy can be named).
+  Abstract-only requests close here; specification is NOT delegated to the
+  detailer.
 
 ### `handoff-detail`
 
@@ -64,8 +70,8 @@ Emit `handoff-detail` only when **both** conditions hold:
    - The function / type / symbol to modify or add.
    - The modification strategy (specific approach, not just "refactor").
 
-If you can only produce an abstract recommendation, fall back to `done`.
-The threshold is strict: one concrete anchor is the minimum.
+If you can only produce an abstract recommendation, fall back to `done`. The
+threshold is strict: one concrete anchor is the minimum.
 
 ## Response comment structure
 
@@ -75,21 +81,26 @@ Use this template. All sections are required.
 ## 検討結果 (Considerer Agent)
 
 ### 質問への回答
+
 <質問 each に対し、コードベース/docs を根拠とした回答。引用可。>
 
 ### 実装要望の評価
+
 <実装要望が含まれていれば、以下を記載:
- - 実装可否 (feasible / infeasible / needs-more-info)
- - 既存設計との整合性
- - 推奨アプローチ (あれば)
- - 実装すべきか見送るかの推奨>
+
+- 実装可否 (feasible / infeasible / needs-more-info)
+- 既存設計との整合性
+- 推奨アプローチ (あれば)
+- 実装すべきか見送るかの推奨>
 
 ### 次アクション
+
 <verdict と対応する結論を1行で:
- - "done (回答済み、実装不要)"
- - "done (回答済み、実装推奨だが抽象論のため本 issue で終了)"
- - "done (infeasible / wontfix)"
- - "handoff-detail (実装推奨: <対象ファイル or 関数 or 方針>)">
+
+- "done (回答済み、実装不要)"
+- "done (回答済み、実装推奨だが抽象論のため本 issue で終了)"
+- "done (infeasible / wontfix)"
+- "handoff-detail (実装推奨: <対象ファイル or 関数 or 方針>)">
 ```
 
 ## Research boundaries

--- a/.agent/considerer/steps_registry.json
+++ b/.agent/considerer/steps_registry.json
@@ -20,7 +20,7 @@
         "issue"
       ],
       "usesStdin": false,
-      "description": "Single-iteration closure: read issue, research, post response, emit verdict (done | handoff-detail), apply done label.",
+      "description": "Single-iteration closure: read issue, research, post response, emit verdict (done | handoff-detail). Orchestrator owns all label/phase transitions via TransactionScope.",
       "outputSchemaRef": {
         "file": "considerer.schema.json",
         "schema": "closure.consider"

--- a/.claude/skills/test-design/SKILL.md
+++ b/.claude/skills/test-design/SKILL.md
@@ -49,6 +49,40 @@ Error messages must state:
 - Which file(s) to fix
 - IF/THEN guidance when multiple fixes are valid
 
+### 4. Does every assertion serve the stated invariant?
+
+テスト 1 個が持つべき invariant は 1 つ (または密結合した少数)。
+
+各 assertion を書く前に「この assert は **テスト名に書いた invariant** を担保しているか?」を問う。担保していない assert は:
+
+- 別テストの責務 (責務重複)、または
+- 証拠に見せかけた over-assertion (assertion bloat)
+
+のどちらか。前者は消す、後者は invariant を言い換えるか消す。
+
+```typescript
+// テスト名: "self-heal: T6 failure recovers + marker is idempotent"
+// 担保すべき invariant: (a) 次 run で completed 到達 (b) comments.length 不変
+
+assertEquals(second.status, "completed");      // ✓ (a)
+assertEquals(github.comments.length, 1);       // ✓ (b)
+assertEquals(labelUpdates.length, 6);          // ✗ label 本数は LIFO 契約テストの責務
+assertEquals(labelUpdates[4].added, ["review"]); // ✗ 順序は transaction-scope_test.ts
+```
+
+### Derivation ladder
+
+expected 値がどこから来るかの優先順位:
+
+```
+✓ import from source of truth      // import { STEP_PHASE }
+✓ compute from named constants     // const FORWARD_OPS = 2; const expected = FORWARD_OPS * 2;
+△ arithmetic with comment          // assertEquals(x, 6) // = 2+2+2  ← 偽装されやすい
+✗ bare literal                      // assertEquals(x, 6)
+```
+
+**`// 2+2+2=6` コメントは derivation ではない**。コメントは腐るし、定数変更時に追従しない。コード-level で導出すること。
+
 ## Test Patterns
 
 ### Contract Test (Layer 1)
@@ -150,6 +184,9 @@ For full message templates and examples, see `references/patterns.md`.
 | Partial consumer enumeration | Contract の消費者が複数あるのにテストが一部しか検査しない | 全ての消費箇所を列挙してからテストを書く |
 | Shadow contract | パラメータ化された経路をバイパスするハードコード値 | ハードコード値をパラメータに置換し、非デフォルト値で回帰テスト |
 | Validator bypass | validator が存在するのにテストが設定を直接検証する | validator の動作をテストする; 検証責任は validator にある |
+| Prose derivation alibi | `// 2+2+2=6` コメントで magic number を "derived" に偽装 | named constant で **コード-level に** 導出 (Derivation ladder 参照) |
+| Assertion bloat | 1 テストが stated invariant 外の assert を抱える (他テストの責務と重複) | invariant 外の assert は削除し、既存の責務テストに委ねる |
+| Delegation trust | sub-agent の skill 適用 summary を検証せず通す | 親が同 skill の lens で re-audit (既存 assert も全スキャン) |
 
 See `references/patterns.md` for detailed explanations of these anti-patterns.
 
@@ -165,6 +202,8 @@ See `references/patterns.md` for detailed explanations of these anti-patterns.
 7. **Craft the error message** — include What/Where/How-to-fix
 8. **Verify non-vacuity** — ensure the test exercises real data
 9. **Hunt shadow contracts** — grep for hardcoded values that bypass the parameterized path
+10. **Scope expansion on review** — 指定された箇所で Anti-Pattern を発見したら、**同ファイル内で grep して同種違反を全スキャン**。レビュー対象行だけ直すのは現状維持バイアス
+11. **Re-audit on delegation** — sub-agent にテスト作成を委譲したら、返ってきた diff に対して親が本 skill の lens で再監査 (特に Derivation ladder, Assertion bloat)
 
 ## Relation to Other Skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `TransactionScope` saga for orchestrator phase transitions: LIFO
+  compensation registry eliminates the "label 宙ぶらり" gap where a
+  label update succeeded but `closeIssue` failed (`agents/orchestrator/transaction-scope.ts`)
+- `reopenIssue` and `getRecentComments` on `GitHubClient` for
+  compensation execution and marker-based idempotency
+- `compensationMarker(issueNumber, cycleSeq)` factory as the single
+  source of truth for compensation comment identity; visible footer
+  signature replaces the HTML-comment marker for operator auditability
+- Self-heal E2E test: T6 failure on one run recovers on the next,
+  with compensation comment posted exactly once across retries
+
+### Changed
+- Orchestrator phase-transition block rewritten as a T1..T7 saga;
+  `cycleTracker.record` now fires only on full T3..T6 success
+- `test-design` skill gains the Derivation ladder (import → named
+  constants → arithmetic-comment → bare literal) and three new
+  anti-patterns: Prose derivation alibi, Assertion bloat, Delegation
+  trust; Decision Framework adds Q4 (assertion-to-invariant alignment)
+- Orchestrator test suite: `labelUpdates.length` expected values
+  derived from `LABEL_CALLS_PER_TRANSITION = 2` (design §2.2) instead
+  of bare literals
+
 ## [1.13.25] - 2026-04-11
 
 ### Fixed

--- a/agents/config/label-existence-validator.ts
+++ b/agents/config/label-existence-validator.ts
@@ -1,0 +1,204 @@
+/**
+ * Label Existence Validator
+ *
+ * Verifies that every label referenced by an agent definition or workflow
+ * configuration is present on the GitHub repository. Prevents runtime
+ * failure where the orchestrator attempts to apply a label that does not
+ * exist on the remote.
+ *
+ * The validator is a Conformance check: two peer configurations (declared
+ * labels vs. labels actually present on the repository) must agree. The
+ * fix direction is fixed — `gh label create <name>`. The config is the
+ * declared intent; GitHub must match it.
+ *
+ * Responsibility: Cross-check declared labels against the repository's
+ * label set (single network read via GitHubClient).
+ * Side effects: One call to `client.listLabels()`.
+ *
+ * @module
+ */
+
+import type { AgentDefinition, ValidationResult } from "../src_common/types.ts";
+import type { GitHubLabelsConfig } from "../src_common/types/agent-definition.ts";
+import type { GitHubClient } from "../orchestrator/github-client.ts";
+import type { WorkflowConfig } from "../orchestrator/workflow-types.ts";
+
+// ---------------------------------------------------------------------------
+// Message constants (exported for test assertions — single source of truth)
+// ---------------------------------------------------------------------------
+
+/** Prefix for label existence errors. */
+export const MSG_LABEL = "[LABEL]";
+
+/** Error fragment: declared label missing on GitHub. */
+export const MSG_LABEL_MISSING =
+  "is declared but does not exist on the repository";
+
+/** Warning fragment: no labels declared anywhere. */
+export const MSG_LABEL_EMPTY = "No labels declared to validate";
+
+/** Warning fragment: GitHubClient unavailable / network failure. */
+export const MSG_LABEL_CLIENT_UNAVAILABLE = "Label existence check skipped";
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract every string label name from a {@link GitHubLabelsConfig} slot.
+ *
+ * Walks all enumerable keys. String values are collected directly. Object
+ * values with shape `{ add?: string[], remove?: string[] }` contribute
+ * every entry of both arrays. `undefined` and unrecognised shapes are
+ * skipped silently (schema validation catches those upstream).
+ *
+ * Exported so tests can exercise the derivation rule in isolation.
+ */
+export function extractLabelsFromGitHubConfig(
+  cfg: GitHubLabelsConfig | undefined,
+): Set<string> {
+  const out = new Set<string>();
+  if (cfg === undefined) return out;
+  for (const value of Object.values(cfg)) {
+    if (typeof value === "string") {
+      out.add(value);
+      continue;
+    }
+    if (value !== undefined && typeof value === "object") {
+      const obj = value as { add?: unknown; remove?: unknown };
+      if (Array.isArray(obj.add)) {
+        for (const v of obj.add) {
+          if (typeof v === "string") out.add(v);
+        }
+      }
+      if (Array.isArray(obj.remove)) {
+        for (const v of obj.remove) {
+          if (typeof v === "string") out.add(v);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** Apply workflow labelPrefix to a bare labelMapping key (mirrors label-resolver). */
+function applyPrefix(bare: string, prefix: string | undefined): string {
+  if (!prefix) return bare;
+  return `${prefix}:${bare}`;
+}
+
+/** Declaration site annotation for diagnostic error messages. */
+type DeclarationSite = "labelMapping" | "GitHubLabelsConfig";
+
+/**
+ * Build the merged declaration map:
+ *   label name → set of sites that declared it
+ *
+ * Kept internal but returned from the validator to make the error shape
+ * data-driven (no string-keyed site lookup in the message builder).
+ */
+function collectDeclarations(
+  definition: AgentDefinition,
+  workflowConfig: WorkflowConfig,
+): Map<string, Set<DeclarationSite>> {
+  const declarations = new Map<string, Set<DeclarationSite>>();
+
+  const add = (label: string, site: DeclarationSite): void => {
+    let sites = declarations.get(label);
+    if (sites === undefined) {
+      sites = new Set();
+      declarations.set(label, sites);
+    }
+    sites.add(site);
+  };
+
+  const prefix = workflowConfig.labelPrefix;
+  for (const bare of Object.keys(workflowConfig.labelMapping)) {
+    add(applyPrefix(bare, prefix), "labelMapping");
+  }
+
+  const ghLabels = definition.runner.integrations?.github?.labels;
+  for (const label of extractLabelsFromGitHubConfig(ghLabels)) {
+    add(label, "GitHubLabelsConfig");
+  }
+
+  return declarations;
+}
+
+/** Join a declaration site set as a stable, human-readable list. */
+function formatSites(sites: Set<DeclarationSite>): string {
+  const ordered: DeclarationSite[] = [];
+  if (sites.has("labelMapping")) ordered.push("labelMapping");
+  if (sites.has("GitHubLabelsConfig")) ordered.push("GitHubLabelsConfig");
+  return ordered.join(" + ");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that every declared label exists on the GitHub repository.
+ *
+ * - declaredLabels = (labelMapping keys, with labelPrefix applied) ∪
+ *                    (strings extracted from runner.integrations.github.labels)
+ * - One call to `client.listLabels()` produces the repository peer set.
+ * - Each declared label missing from the peer set produces one error.
+ * - Empty declared set produces a single warning (non-vacuity guard).
+ * - Client failures produce a single warning; `valid` stays true (skip
+ *   semantics — validator is online-only by design).
+ *
+ * @param definition - Parsed agent definition
+ * @param workflowConfig - Loaded workflow configuration
+ * @param client - GitHub client abstraction; injected for testability
+ * @returns Validation result (errors for missing labels, warnings for skips)
+ */
+export async function validateLabelExistence(
+  definition: AgentDefinition,
+  workflowConfig: WorkflowConfig,
+  client: GitHubClient,
+): Promise<ValidationResult> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const declarations = collectDeclarations(definition, workflowConfig);
+
+  if (declarations.size === 0) {
+    return {
+      valid: true,
+      errors: [],
+      warnings: [`${MSG_LABEL} ${MSG_LABEL_EMPTY}`],
+    };
+  }
+
+  let existing: Set<string>;
+  try {
+    const labels = await client.listLabels();
+    existing = new Set(labels);
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      valid: true,
+      errors: [],
+      warnings: [
+        `${MSG_LABEL} ${MSG_LABEL_CLIENT_UNAVAILABLE}: ${msg}`,
+      ],
+    };
+  }
+
+  for (const [label, sites] of declarations) {
+    if (existing.has(label)) continue;
+    const site = formatSites(sites);
+    errors.push(
+      `${MSG_LABEL} label '${label}' ${MSG_LABEL_MISSING} ` +
+        `(declared in ${site}). ` +
+        `How-to-fix: Run 'gh label create ${JSON.stringify(label)}'`,
+    );
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}

--- a/agents/config/label-existence-validator_test.ts
+++ b/agents/config/label-existence-validator_test.ts
@@ -1,0 +1,435 @@
+/**
+ * Tests for agents/config/label-existence-validator.ts
+ *
+ * Conformance Test pattern (per /test-design skill):
+ *   declared labels (labelMapping + runner.integrations.github.labels)
+ *     must match the repository's actual label set.
+ *
+ * Test rules:
+ * - Expected values are derived from the fixture, not hardcoded.
+ * - Every fixture declares at least one label (non-vacuity guard).
+ * - Error messages must include the missing label name.
+ * - Message phrasing is asserted via exported constants.
+ */
+
+import { assertEquals, assertGreater, assertStringIncludes } from "@std/assert";
+import type {
+  AgentDefinition,
+  GitHubLabelsConfig,
+} from "../src_common/types.ts";
+import type { GitHubClient } from "../orchestrator/github-client.ts";
+import type { WorkflowConfig } from "../orchestrator/workflow-types.ts";
+import {
+  extractLabelsFromGitHubConfig,
+  MSG_LABEL,
+  MSG_LABEL_CLIENT_UNAVAILABLE,
+  MSG_LABEL_EMPTY,
+  MSG_LABEL_MISSING,
+  validateLabelExistence,
+} from "./label-existence-validator.ts";
+
+// ---------------------------------------------------------------------------
+// Source file reference for diagnostic messages
+// ---------------------------------------------------------------------------
+
+const SRC = "label-existence-validator.ts";
+
+// ---------------------------------------------------------------------------
+// Minimal fake GitHubClient — only listLabels matters for this validator.
+// Unused methods throw to surface accidental usage in a test.
+// ---------------------------------------------------------------------------
+
+function fakeClient(
+  labels: readonly string[] | (() => Promise<string[]>),
+): GitHubClient {
+  const impl: Partial<GitHubClient> = {
+    listLabels: typeof labels === "function"
+      ? labels
+      : () => Promise.resolve([...labels]),
+  };
+  const unsupported = (name: string) => () => {
+    throw new Error(`fakeClient: ${name} not implemented for this test`);
+  };
+  return {
+    listLabels: impl.listLabels!,
+    getIssueLabels: unsupported("getIssueLabels"),
+    updateIssueLabels: unsupported("updateIssueLabels"),
+    addIssueComment: unsupported("addIssueComment"),
+    createIssue: unsupported("createIssue"),
+    closeIssue: unsupported("closeIssue"),
+    reopenIssue: unsupported("reopenIssue"),
+    listIssues: unsupported("listIssues"),
+    getIssueDetail: unsupported("getIssueDetail"),
+    getRecentComments: unsupported("getRecentComments"),
+  } as GitHubClient;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeDefinition(labels?: GitHubLabelsConfig): AgentDefinition {
+  return {
+    version: "1.0.0",
+    name: "test-agent",
+    displayName: "Test Agent",
+    description: "Fixture for label-existence validator",
+    parameters: {},
+    runner: {
+      flow: {
+        systemPromptPath: "system.md",
+        prompts: { registry: "steps_registry.json" },
+      },
+      verdict: {
+        type: "detect:graph",
+        config: { registryPath: "steps_registry.json" },
+      },
+      boundaries: {
+        allowedTools: [],
+        permissionMode: "default",
+      },
+      integrations: labels === undefined
+        ? undefined
+        : { github: { enabled: true, labels } },
+    },
+  };
+}
+
+function makeWorkflow(
+  labelMapping: Record<string, string>,
+  labelPrefix?: string,
+): WorkflowConfig {
+  return {
+    version: "1.0.0",
+    labelPrefix,
+    phases: {
+      plan: { type: "actionable", priority: 1, agent: "planner" },
+      done: { type: "terminal" },
+    },
+    labelMapping,
+    agents: {
+      planner: { role: "transformer", outputPhase: "done" },
+    },
+    rules: { maxCycles: 5, cycleDelayMs: 0 },
+  };
+}
+
+/** Derive the declared label set exactly as the validator does. */
+function declaredSet(
+  def: AgentDefinition,
+  wf: WorkflowConfig,
+): Set<string> {
+  const out = new Set<string>();
+  const prefix = wf.labelPrefix;
+  for (const bare of Object.keys(wf.labelMapping)) {
+    out.add(prefix ? `${prefix}:${bare}` : bare);
+  }
+  for (
+    const l of extractLabelsFromGitHubConfig(
+      def.runner.integrations?.github?.labels,
+    )
+  ) {
+    out.add(l);
+  }
+  return out;
+}
+
+// =============================================================================
+// Case 1: All declared labels exist -> valid=true, zero errors
+// =============================================================================
+
+Deno.test("label-existence - all declared labels exist returns valid", async () => {
+  const def = makeDefinition({ requirements: "ready", inProgress: "review" });
+  const wf = makeWorkflow({ ready: "plan", review: "plan" });
+  const declared = declaredSet(def, wf);
+  assertGreater(
+    declared.size,
+    0,
+    `Non-vacuity: fixture must declare at least one label (fix: ${SRC} test fixture)`,
+  );
+
+  const client = fakeClient([...declared]);
+  const result = await validateLabelExistence(def, wf, client);
+
+  assertEquals(
+    result.valid,
+    true,
+    `Expected valid=true when every declared label exists (fix: ${SRC}). ` +
+      `Got errors: ${result.errors.join("; ")}`,
+  );
+  assertEquals(
+    result.errors.length,
+    0,
+    `Expected 0 errors when every declared label exists. Got: ${
+      result.errors.join("; ")
+    }`,
+  );
+});
+
+// =============================================================================
+// Case 2: One label missing in labelMapping only
+// =============================================================================
+
+Deno.test("label-existence - missing labelMapping label errors with site", async () => {
+  const def = makeDefinition({ requirements: "ready" });
+  const wf = makeWorkflow({ ready: "plan", review: "plan" });
+  const declared = declaredSet(def, wf);
+  assertGreater(
+    declared.size,
+    0,
+    `Non-vacuity: fixture must declare at least one label (fix: ${SRC})`,
+  );
+
+  // "review" is only in labelMapping (not in GitHub config labels).
+  const existing = new Set([...declared].filter((l) => l !== "review"));
+  const expectedMissing = [...declared].filter((l) => !existing.has(l));
+  assertEquals(
+    expectedMissing,
+    ["review"],
+    "Test setup: expected exactly one missing label ('review') declared solely in labelMapping",
+  );
+
+  const result = await validateLabelExistence(
+    def,
+    wf,
+    fakeClient([...existing]),
+  );
+
+  assertEquals(
+    result.valid,
+    false,
+    `Expected valid=false when a declared label is missing (fix: ${SRC})`,
+  );
+  assertEquals(
+    result.errors.length,
+    expectedMissing.length,
+    `Expected ${expectedMissing.length} error(s) = |declaredLabels| - |existing ∩ declaredLabels|`,
+  );
+  const msg = result.errors[0];
+  assertStringIncludes(msg, MSG_LABEL);
+  assertStringIncludes(msg, MSG_LABEL_MISSING);
+  assertStringIncludes(msg, expectedMissing[0]);
+  assertStringIncludes(msg, "labelMapping");
+});
+
+// =============================================================================
+// Case 3: One label missing in GitHubLabelsConfig only
+// =============================================================================
+
+Deno.test("label-existence - missing GitHubLabelsConfig label errors with site", async () => {
+  const def = makeDefinition({ requirements: "gap" });
+  const wf = makeWorkflow({ ready: "plan" });
+  const declared = declaredSet(def, wf);
+  assertGreater(
+    declared.size,
+    0,
+    `Non-vacuity: fixture must declare at least one label (fix: ${SRC})`,
+  );
+
+  // "gap" is only in GitHubLabelsConfig (not in labelMapping).
+  const existing = new Set([...declared].filter((l) => l !== "gap"));
+  const expectedMissing = [...declared].filter((l) => !existing.has(l));
+  assertEquals(
+    expectedMissing,
+    ["gap"],
+    "Test setup: expected exactly one missing label ('gap') declared solely in GitHubLabelsConfig",
+  );
+
+  const result = await validateLabelExistence(
+    def,
+    wf,
+    fakeClient([...existing]),
+  );
+
+  assertEquals(result.valid, false);
+  assertEquals(result.errors.length, expectedMissing.length);
+  const msg = result.errors[0];
+  assertStringIncludes(msg, MSG_LABEL_MISSING);
+  assertStringIncludes(msg, expectedMissing[0]);
+  assertStringIncludes(msg, "GitHubLabelsConfig");
+});
+
+// =============================================================================
+// Case 4: Label missing from both sites -> single error citing both
+// =============================================================================
+
+Deno.test("label-existence - label declared in both sites reported once with both sites", async () => {
+  // Same literal "review" declared in labelMapping AND GitHubLabelsConfig.
+  const def = makeDefinition({ requirements: "review" });
+  const wf = makeWorkflow({ review: "plan" });
+  const declared = declaredSet(def, wf);
+  assertEquals(
+    declared.size,
+    1,
+    "Test setup: expected both declaration sites to collapse into a single label",
+  );
+  assertGreater(
+    declared.size,
+    0,
+    `Non-vacuity: fixture must declare at least one label (fix: ${SRC})`,
+  );
+
+  const expectedMissing = [...declared];
+  const result = await validateLabelExistence(def, wf, fakeClient([]));
+
+  assertEquals(result.errors.length, expectedMissing.length);
+  const msg = result.errors[0];
+  assertStringIncludes(msg, MSG_LABEL_MISSING);
+  assertStringIncludes(msg, expectedMissing[0]);
+  assertStringIncludes(msg, "labelMapping");
+  assertStringIncludes(msg, "GitHubLabelsConfig");
+});
+
+// =============================================================================
+// Case 5: Client returns empty list -> every declared label errors
+// =============================================================================
+
+Deno.test("label-existence - empty repo label set errors every declared label", async () => {
+  const def = makeDefinition({ requirements: "ready", inProgress: "review" });
+  const wf = makeWorkflow({ ready: "plan", blocked: "done" });
+  const declared = declaredSet(def, wf);
+  assertGreater(
+    declared.size,
+    0,
+    `Non-vacuity: fixture must declare at least one label (fix: ${SRC})`,
+  );
+
+  const existing = new Set<string>();
+  const expectedMissing = [...declared].filter((l) => !existing.has(l));
+  // Derivation check: with empty repo, every declared label is missing.
+  assertEquals(expectedMissing.length, declared.size);
+
+  const result = await validateLabelExistence(def, wf, fakeClient([]));
+
+  assertEquals(result.valid, false);
+  assertEquals(
+    result.errors.length,
+    expectedMissing.length,
+    `Expected |declaredLabels| errors when repo is empty (got ${result.errors.length}, expected ${expectedMissing.length})`,
+  );
+  // Every declared label name must appear somewhere in the error list.
+  for (const label of expectedMissing) {
+    const hit = result.errors.some((e) => e.includes(label));
+    assertEquals(
+      hit,
+      true,
+      `Expected an error message to mention missing label '${label}'. Got: ${
+        result.errors.join(" | ")
+      }`,
+    );
+  }
+});
+
+// =============================================================================
+// Case 6: Client throws -> single warning, valid=true (skip semantics)
+// =============================================================================
+
+Deno.test("label-existence - client failure produces single warning and valid=true", async () => {
+  const def = makeDefinition({ requirements: "ready" });
+  const wf = makeWorkflow({ ready: "plan" });
+  const declared = declaredSet(def, wf);
+  assertGreater(
+    declared.size,
+    0,
+    `Non-vacuity: fixture must declare at least one label (fix: ${SRC})`,
+  );
+
+  const failing = fakeClient(() => {
+    return Promise.reject(new Error("gh auth required"));
+  });
+
+  const result = await validateLabelExistence(def, wf, failing);
+
+  assertEquals(
+    result.valid,
+    true,
+    "Client failure must not fail validation (skip semantics)",
+  );
+  assertEquals(result.errors.length, 0);
+  assertEquals(
+    result.warnings.length,
+    1,
+    `Expected exactly 1 skip warning, got ${result.warnings.length}: ${
+      result.warnings.join(" | ")
+    }`,
+  );
+  assertStringIncludes(result.warnings[0], MSG_LABEL_CLIENT_UNAVAILABLE);
+  assertStringIncludes(result.warnings[0], "gh auth required");
+});
+
+// =============================================================================
+// Empty-declaration non-vacuity guard: warning, valid=true
+// =============================================================================
+
+Deno.test("label-existence - empty declarations produce non-vacuity warning", async () => {
+  const def = makeDefinition(); // no integrations.github.labels
+  const wf = makeWorkflow({}); // no labelMapping entries
+
+  const declared = declaredSet(def, wf);
+  assertEquals(
+    declared.size,
+    0,
+    "Test setup: this case exercises the empty-declaration path specifically",
+  );
+
+  const result = await validateLabelExistence(def, wf, fakeClient([]));
+
+  assertEquals(result.valid, true);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.warnings.length, 1);
+  assertStringIncludes(result.warnings[0], MSG_LABEL_EMPTY);
+});
+
+// =============================================================================
+// extractLabelsFromGitHubConfig — unit coverage
+// =============================================================================
+
+Deno.test("extractLabelsFromGitHubConfig - undefined yields empty set", () => {
+  const out = extractLabelsFromGitHubConfig(undefined);
+  assertEquals(out.size, 0);
+});
+
+Deno.test("extractLabelsFromGitHubConfig - string slots are included", () => {
+  const cfg: GitHubLabelsConfig = {
+    requirements: "ready",
+    inProgress: "review",
+  };
+  const out = extractLabelsFromGitHubConfig(cfg);
+  const expected = new Set(["ready", "review"]);
+  assertEquals(
+    out.size,
+    expected.size,
+    `Expected ${expected.size} labels (one per string slot), got ${out.size}`,
+  );
+  for (const v of expected) {
+    assertEquals(out.has(v), true, `expected to include '${v}'`);
+  }
+});
+
+Deno.test("extractLabelsFromGitHubConfig - add/remove arrays are both included", () => {
+  const cfg: GitHubLabelsConfig = {
+    completion: { add: ["approved", "closed"], remove: ["review"] },
+  };
+  const out = extractLabelsFromGitHubConfig(cfg);
+  const expected = new Set(["approved", "closed", "review"]);
+  assertEquals(
+    out.size,
+    expected.size,
+    `Expected ${expected.size} labels from add+remove, got ${out.size}: ${
+      [...out].join(",")
+    }`,
+  );
+  for (const v of expected) {
+    assertEquals(out.has(v), true, `expected to include '${v}'`);
+  }
+});
+
+Deno.test("extractLabelsFromGitHubConfig - agent-specific string keys are included", () => {
+  const cfg: GitHubLabelsConfig = {
+    review: "review",
+    gap: "gap",
+  };
+  const out = extractLabelsFromGitHubConfig(cfg);
+  assertEquals(out.has("review"), true);
+  assertEquals(out.has("gap"), true);
+});

--- a/agents/config/mod.ts
+++ b/agents/config/mod.ts
@@ -41,6 +41,15 @@ import {
   validateStepRegistry,
 } from "../common/step-registry/validator.ts";
 import type { StepRegistry } from "../common/step-registry/types.ts";
+import {
+  MSG_LABEL,
+  MSG_LABEL_CLIENT_UNAVAILABLE,
+  validateLabelExistence,
+} from "./label-existence-validator.ts";
+import { loadWorkflow } from "../orchestrator/workflow-loader.ts";
+import type { WorkflowConfig } from "../orchestrator/workflow-types.ts";
+import type { GitHubClient } from "../orchestrator/github-client.ts";
+import { GhCliClient } from "../orchestrator/github-client.ts";
 
 // Re-export for convenience
 export { validate, validateComplete } from "./validator.ts";
@@ -133,6 +142,7 @@ export interface FullValidationResult {
   registrySchemaResult: SchemaValidationResult | null;
   crossRefResult: CrossRefResult | null;
   pathResult: ValidationResult | null;
+  labelExistenceResult: ValidationResult | null;
   flowResult: ValidationResult | null;
   promptResult: ValidationResult | null;
   uvReachabilityResult: ValidationResult | null;
@@ -141,6 +151,15 @@ export interface FullValidationResult {
   stepRegistryValidation: ValidationResult | null;
   handoffInputsResult: ValidationResult | null;
   configRegistryResult: ValidationResult | null;
+}
+
+/**
+ * Optional dependencies for {@link validateFull}. Injected for testability —
+ * production callers omit this argument and the real `gh` CLI client is
+ * constructed automatically.
+ */
+export interface ValidateFullOptions {
+  githubClient?: GitHubClient;
 }
 
 /**
@@ -157,6 +176,7 @@ export interface FullValidationResult {
 export async function validateFull(
   agentName: string,
   baseDir: string,
+  opts?: ValidateFullOptions,
 ): Promise<FullValidationResult> {
   const agentDir = getAgentDir(agentName, baseDir);
 
@@ -266,6 +286,16 @@ export async function validateFull(
     promptRoot,
   );
 
+  // 6a. Label existence validation — online conformance check between declared
+  //     labels (labelMapping + runner.integrations.github.labels) and the
+  //     repository's actual label set. Skipped with a warning when the
+  //     workflow config is absent or the GitHub client cannot be obtained.
+  const labelExistenceResult = await runLabelExistenceValidation(
+    definition,
+    baseDir,
+    opts?.githubClient,
+  );
+
   // 6b. Flow reachability validation (only when registry exists)
   const flowResult = registry ? validateFlowReachability(registry) : null;
 
@@ -308,6 +338,7 @@ export async function validateFull(
     (registrySchemaResult?.valid ?? true) &&
     (crossRefResult?.valid ?? true) &&
     pathResult.valid &&
+    (labelExistenceResult?.valid ?? true) &&
     (flowResult?.valid ?? true) &&
     (promptResult?.valid ?? true) &&
     (uvReachabilityResult?.valid ?? true) &&
@@ -324,6 +355,7 @@ export async function validateFull(
     registrySchemaResult,
     crossRefResult,
     pathResult,
+    labelExistenceResult,
     flowResult,
     promptResult,
     uvReachabilityResult,
@@ -369,4 +401,52 @@ function extractRegistryPath(raw: unknown): string | undefined {
   }
   const registry = (prompts as Record<string, unknown>).registry;
   return typeof registry === "string" ? registry : undefined;
+}
+
+/**
+ * Run the label-existence validator with appropriate skip semantics.
+ *
+ * Skip with a warning when:
+ * - workflow.json cannot be located/parsed (the validator needs `labelMapping`
+ *   to know which labels participate in phase transitions)
+ * - the GitHubClient constructor throws (so offline `--validate` runs stay
+ *   useful for the non-network checks)
+ *
+ * Returning `null` is reserved for "validator not applicable"; all other
+ * skips surface as warnings so the author sees they were not checked.
+ */
+async function runLabelExistenceValidation(
+  definition: AgentDefinition,
+  baseDir: string,
+  injectedClient: GitHubClient | undefined,
+): Promise<ValidationResult> {
+  let workflowConfig: WorkflowConfig;
+  try {
+    workflowConfig = await loadWorkflow(baseDir);
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      valid: true,
+      errors: [],
+      warnings: [
+        `${MSG_LABEL} ${MSG_LABEL_CLIENT_UNAVAILABLE}: workflow config unavailable: ${msg}`,
+      ],
+    };
+  }
+
+  let client: GitHubClient;
+  try {
+    client = injectedClient ?? new GhCliClient(baseDir);
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      valid: true,
+      errors: [],
+      warnings: [
+        `${MSG_LABEL} ${MSG_LABEL_CLIENT_UNAVAILABLE}: ${msg}`,
+      ],
+    };
+  }
+
+  return await validateLabelExistence(definition, workflowConfig, client);
 }

--- a/agents/docs/design/04_step_flow_design.md
+++ b/agents/docs/design/04_step_flow_design.md
@@ -318,6 +318,72 @@ flowchart LR
   4. `completionHandler.onBoundaryHook()` が `gh` コマンドを Runner プロセス
      内で実行（AI の bash ツール経由ではない）
 
+#### intent と Phase 遷移 Transaction の接続
+
+Flow 側の intent は Step の遷移先を選ぶだけで、Issue 状態そのものを変更しない。
+Issue 状態の変更 (label 付け替え / handoff comment / issue close) は、Closure
+Step が `closing` intent を出した後、Runner Boundary Hook を経由して
+Orchestrator 側の **Phase 遷移 Transaction** (`TransactionScope`) が担う。
+
+| intent     | 発行元 Step                        | Flow 側の挙動                                             | Orchestrator 側 gh 副作用                     |
+| ---------- | ---------------------------------- | --------------------------------------------------------- | --------------------------------------------- |
+| `next`     | Work / Verification Step           | `transitions.next` の Step へ進む                         | なし                                          |
+| `repeat`   | Work / Verification / Closure Step | 同 Step を再実行                                          | なし                                          |
+| `jump`     | Work / Verification Step           | `targetStepId` の Step へ跳ぶ                             | なし                                          |
+| `escalate` | Verification Step                  | support Step へ誘導 (デフォルトは `continuation.default`) | なし                                          |
+| `handoff`  | 後続 Work Step                     | `closure.<domain>` (Closure Step) へ遷移                  | なし                                          |
+| `closing`  | Closure Step                       | Flow End へ (`target: null`)                              | Boundary Hook → Phase 遷移 Transaction が起動 |
+
+`closing` intent だけが Orchestrator の TransactionScope を起動する、という 1:1
+対応が本設計の境界となる (詳細: `12_orchestrator.md` の「Phase 遷移
+Transaction」)。
+
+##### closing intent から transaction 起動までの流れ
+
+```mermaid
+sequenceDiagram
+  participant Closure as Closure Step
+  participant Gate as Gate + Router
+  participant Hook as Boundary Hook (Runner)
+  participant Orch as Orchestrator cycle
+  participant Scope as TransactionScope
+
+  Closure-->>Gate: structured output (intent="closing")
+  Gate->>Hook: signalCompletion=true
+  Hook-->>Orch: AgentResult (verdict, handoff)
+  Orch->>Scope: new TransactionScope()
+  Scope->>Scope: T3 add-labels → T4 remove-labels
+  Scope->>Scope: T5 handoff-comment → T6 close (pre-register compensation)
+  alt 全成功
+    Orch->>Scope: commit()
+    Orch->>Orch: tracker.record + T7 local persist
+  else 途中失敗
+    Orch->>Scope: rollback(error) → LIFO 補償
+    Orch->>Orch: status="blocked"
+    Note over Orch: 次サイクルで同 phase 再試行（セルフヒール）
+  end
+```
+
+##### Transaction 失敗時の自己修復
+
+Phase 遷移 Transaction が途中失敗して rollback した場合、Orchestrator は当該
+サイクルを `status="blocked"` で終える。`break` でループを抜けるが、
+`cycleTracker.record` は走らないため **maxCycles カウンタは増えない**。次回
+`run()` 呼び出し時には:
+
+1. gh から最新 labels を再取得 (Dual Truth Source: `run()` は常に gh を source
+   of truth とする)
+2. 補償で preImage に復元された labels から `resolvePhase` が **元の phase**
+   を再解決
+3. 同じ actionable phase に対し Agent を再ディスパッチ
+4. 再度 Closure Step まで到達すれば、新規 `cycleSeq` で新しい `TransactionScope`
+   が起動 (補償マーカーの `cycleSeq` が異なるため、前回失敗の compensation
+   comment と混在しない)
+
+この流れにより、「AI 的な判断を再度行わずに」外部障害 (gh rate limit / network)
+を乗り越えられる。Flow 側で intent を作り直す必要はなく、Flow と Transaction
+の責務が明確に分離される。
+
 #### 決定論的サンドボックス制御
 
 Boundary Hook に加え、サンドボックスのネットワーク遮断が Agent の GitHub

--- a/agents/docs/design/09_contracts.md
+++ b/agents/docs/design/09_contracts.md
@@ -191,6 +191,84 @@ StepMachineVerdictHandler が内部に遷移ロジック (transition, getNextSte
    - 外部条件 → true
 ```
 
+## Phase 遷移の契約
+
+Orchestrator が 1 サイクル内で実行する gh 複合操作 (label add / label remove /
+handoff comment / close) の一貫性を定義する契約。適用先の詳細シーケンスと補償
+マトリクスは `12_orchestrator.md` の「Phase 遷移 Transaction」セクション参照。
+
+### 不変条件
+
+```
+phase 遷移は unit-atomic である
+
+- T3..T6 全成功 ⇒ tracker.record + commit (状態確定)
+- いずれか失敗 ⇒ rollback (補償を LIFO 実行) + status="blocked" + next-cycle retry
+- 中間状態で観測されない: 「label は付いたが issue は open」「close したが
+  label は旧 phase のまま」等の片側成功は発生しない
+
+cycleTracker.record は全 T 成功時のみ起動する
+  ⇒ 部分失敗サイクルが次サイクル判定を歪めない
+```
+
+### 判断基準: TransactionScope を使うか
+
+```
+問い: 「片側成功で issue の観測状態が壊れる操作群か?」
+
+Yes ⇒ TransactionScope に閉じ込める
+No  ⇒ 独立した try/catch で best-effort 実行でよい
+```
+
+### 使用判断表
+
+| ケース                                            | 判断 | 根拠                                                      |
+| ------------------------------------------------- | ---- | --------------------------------------------------------- |
+| Phase 遷移 (label add + remove + comment + close) | 必要 | close 失敗で label 宙ぶらり (G2) が発生する               |
+| 単発 comment 投稿                                 | 不要 | 失敗しても他の状態を壊さない、単独の try/catch で足りる   |
+| 独立な複数 issue の順次操作 (batch)               | 不要 | issue 間に依存なし。issue 単位で個別に scope を作ればよい |
+| pure 計算 (computeLabelChanges 等)                | 不要 | 副作用がないため補償対象外                                |
+
+### Compensation の契約
+
+```
+record(compensation) → void
+  入力: { label, idempotencyKey, run: () => Promise<void> }
+  副作用: LIFO スタックへ push
+  前提: scope が open 状態
+  保証: committed / rolledBack 状態では no-op
+
+commit() → Promise<void>
+  副作用: 補償スタックを破棄、状態を committed へ遷移
+  保証: 冪等 (再呼び出しは no-op)
+
+rollback(cause) → Promise<CompensationReport>
+  副作用: 補償を LIFO で実行。個別失敗は捕捉され report.failed に集約
+  保証: throw しない。logger 自身の例外も rollback を止めない
+        report.partial = succeeded < attempted
+
+Compensation.run() の責務:
+  - 冪等性: 同 idempotencyKey での 2 回実行で副作用が重複しない
+    (例: compensation comment は `orchestrator.ts` の compensationMarker
+    factory から得た文字列を事前検索して skip。形式・表示は同ファイル
+    を唯一の source of truth とする)
+  - retry: 必要なら run() 内部で実装する (TransactionScope は関与しない)
+```
+
+### VerdictHandler 契約との整合
+
+VerdictHandler は Agent 完了を判定するだけで、外部副作用は onBoundaryHook
+を単一の出口として実行する (上述「VerdictHandler の責務外」参照)。Orchestrator
+側の Phase 遷移 Transaction は **この Boundary Hook の下流** で動作し、
+VerdictHandler が verdict を確定した「後」の gh 複合操作の原子性を保証する。
+両者は別レイヤーの契約であり、以下の分担を守る:
+
+```
+VerdictHandler:       Agent 完了の判定 (isFinished) まで
+Boundary Hook:        closing intent 確認 → Runner プロセスで gh 実行
+Phase 遷移 Transaction: Orchestrator サイクル内の gh 複合操作を unit-atomic に統合
+```
+
 ## 接続の契約
 
 ### LLM 問い合わせ

--- a/agents/docs/design/12_orchestrator.md
+++ b/agents/docs/design/12_orchestrator.md
@@ -286,24 +286,147 @@ Agent は gh 操作をファイルとして `outbox/` に書き出す。Orchestr
 
 v1.14 では `run()` がストアを単一の真実源として使用し、この二重基準を解消する。
 
+## Phase 遷移 Transaction
+
+Phase 遷移に伴う gh 複合操作 (label add / label remove / handoff comment /
+close) を unit-atomic に扱うための saga スコープ。単一サイクルの副作用を 1 つの
+`TransactionScope` に束ね、途中失敗時は LIFO で補償を走らせて issue の観測状態を
+一貫させる。
+
+- **Level 1 (Why)**: label だけ付いて issue が open のまま残る「G2 label
+  宙ぶらり」等の片側成功を阻止し、phase 遷移を unit-atomic に保つため。
+- 契約とパターンの source of truth: `agents/docs/design/09_contracts.md` の
+  「Phase 遷移の契約」セクション。ここでは Orchestrator 側の適用と補償挙動のみ
+  記述する。
+
+### T1〜T7 シーケンス
+
+`agents/orchestrator/orchestrator.ts:484-720` の実装と 1:1 対応する。pure
+計算→可逆操作→不可逆操作の順で、各境界で fail-fast する。
+
+```
+T1  pure: compute plan = { labelsToAdd, labelsToRemove, handoffComment?, closeIntent? }
+T2  snapshot: preImage = currentLabels, cycleSeq = tracker.getCount(n) + 1
+T3  scope.step("add-labels", gh.updateIssueLabels([], add),
+        compensation: gh.updateIssueLabels(add, []))
+T4  scope.step("remove-labels", gh.updateIssueLabels(remove, []),
+        compensation: gh.updateIssueLabels([], remove))
+T5  scope.step("handoff-comment", handoff.renderAndPost(...),
+        compensation: restore preImage labels)
+T6  scope.record({ label: "compensation-comment", ... });   // pre-register
+    await gh.closeIssue(n);                                 // irreversible
+T_rec  tracker.record(...)     // T3..T6 全成功時のみ
+T_commit  scope.commit()       // 補償スタックを破棄
+T7  store.updateMeta / writeWorkflowState   // best-effort、commit 後
+        ─ 失敗は次サイクル頭の gh 再読込でセルフヒール
+
+途中失敗:  catch → scope.rollback(err) が LIFO で補償を実行
+           → status="blocked" で break、次サイクルで同 phase を再試行
+finally:   commit も rollback も走らなかった場合の保険として rollback を呼ぶ
+```
+
+### 可逆性分類
+
+| 操作                 | 可逆性     | 冪等性                            | 反対操作     |
+| -------------------- | ---------- | --------------------------------- | ------------ |
+| label 追加           | 可逆       | 冪等 (gh は重複追加を no-op 扱い) | label 削除   |
+| label 削除           | 可逆       | 冪等                              | label 追加   |
+| handoff comment      | **不可逆** | 非冪等 (重複投稿)                 | 追記 comment |
+| issue close          | 可逆       | 冪等 (既 close は 409 = 実質成功) | reopen       |
+| issue reopen         | 可逆       | 冪等                              | close        |
+| compensation comment | **不可逆** | マーカーで冪等化 (下記参照)       | —            |
+
+**原則**: 可逆で冪等な操作から並べ、不可逆な状態変化 (close) を最後に置く。
+前段失敗時は後段をスキップし、既成功ぶんだけを補償で巻き戻す。
+
+### 補償マトリクス
+
+failed step に対し、どこまでの step が成功しているかで補償内容が決まる。
+
+| 成功した step     | 失敗した step    | 補償シーケンス                                   | 冪等性         |
+| ----------------- | ---------------- | ------------------------------------------------ | -------------- |
+| (なし)            | T3 add-labels    | なし (状態変化なし)                              | —              |
+| T3                | T4 remove-labels | T3 で add した label を remove                   | 冪等 (gh)      |
+| T3 + T4           | T5 handoff       | label を preImage に復元 (add ↔ remove 逆)       | 冪等 (gh)      |
+| T3 + T4 + T5      | T6 close         | **補償 comment 追記** (マーカー付き)             | マーカーで冪等 |
+| T3 + T4 + T5 + T6 | T7 local persist | 補償不要。次サイクル頭の gh 再読込でセルフヒール | —              |
+
+補償自身の失敗は `CompensationReport.failed` に集約され rollback は throw しない
+(`agents/orchestrator/transaction-scope.ts:116-160`)。log に
+`event:
+"compensation_ran"` / `"compensation_failed"` を残し、呼び出し側
+(orchestrator) は status="blocked"
+で当該サイクルを終え、次サイクルで再試行する。
+
+### 補償マーカーによる冪等化
+
+補償 comment は gh に delete API が無いため不可逆。再実行時の重複投稿を防ぐため
+決定論的マーカーを body に埋め込む。
+
+**source of truth**: `agents/orchestrator/orchestrator.ts` に export された
+`compensationMarker(issueNumber, cycleSeq)` factory を唯一の生成元とする。
+producer (T6 rollback の comment body 組み立て) と consumer (`getRecentComments`
+による事前 dedup チェック) は共にこの factory から文字列を取得する。テストも 同
+factory を import して期待値を導出する。
+
+**表示形式**: 可視 footer 署名方式。comment 本文末尾に `<sub>🤖 <marker></sub>`
+として埋め込む (旧: 不可視 HTML コメント `<!-- ... -->` は廃止)。ユーザが GitHub
+UI 上で補償 comment を 視認できることを優先しつつ、マーカー文字列は grep
+可能な形で保持する。
+
+**冪等性プロトコル**:
+
+1. 補償実行時に `github.getRecentComments(n, 20)` でマーカー存在を確認
+2. マーカーが見つかれば skip (return 早期リターン)
+3. 見つからなければ body に同マーカーを付けて `addIssueComment` を投稿
+
+参照実装: `agents/orchestrator/orchestrator.ts` の `compensationMarker` export
+と T6 の pre-register 箇所。
+
+### TransactionScope API (要約)
+
+実装: `agents/orchestrator/transaction-scope.ts`。契約の source of truth
+はコード コメント (同ファイル L20-30) 側。
+
+| メソッド                       | 役割                                                           |
+| ------------------------------ | -------------------------------------------------------------- |
+| `step(label, action, factory)` | action を実行し、成功時のみ factory() が返す補償を push        |
+| `record(comp)`                 | action を伴わず補償を先行登録 (T6 close の pre-register 用)    |
+| `commit()`                     | 補償スタックを破棄し `committed` 状態へ遷移 (冪等)             |
+| `rollback(cause)`              | LIFO で補償を実行し `CompensationReport` を返す (throw しない) |
+
+**不変条件**:
+
+- `record` / `step` は `state !== "open"` では no-op (commit/rollback
+  後の呼び出し は無視)
+- 補償は全て best-effort。個別失敗は `report.failed` に収集され、
+  `report.partial=true` として surface される
+- retry policy は各 `Compensation.run` の内部責務。TransactionScope は関与しない
+
+### 適用範囲
+
+TransactionScope は `GitHubClient` interface にしか依存せず、orchestrator の
+メインループ (phase 遷移) における gh 複合操作を unit-atomic に統合する。
+
 ## コンポーネント一覧
 
-| モジュール             | What                                               | Why                                    |
-| ---------------------- | -------------------------------------------------- | -------------------------------------- |
-| `workflow-loader.ts`   | workflow.json 読み込み・スキーマ検証・相互参照検証 | 設定漏れを起動前に排除                 |
-| `workflow-types.ts`    | Phase, Agent, Transition 等の型定義                | 全モジュールの型安全性を保証           |
-| `workflow-schema.json` | JSON Schema                                        | IDE 補完とバリデーション               |
-| `label-resolver.ts`    | Label → Phase → Agent 解決                         | priority による優先度制御              |
-| `phase-transition.ts`  | 遷移ロジック・ラベル変更計算・テンプレート展開     | Agent から遷移ロジックを分離           |
-| `cycle-tracker.ts`     | Issue ごとの遷移回数追跡                           | maxCycles でループ防止                 |
-| `dispatcher.ts`        | Agent 起動・完了ハンドリング                       | Runner 呼び出しのラッパー              |
-| `github-client.ts`     | gh コマンドのラッパー                              | gh アクセスを単一モジュールに集約      |
-| `orchestrator.ts`      | メインループ（全モジュール統合）                   | 単一 issue サイクル + batch 処理       |
-| `issue-store.ts`       | ローカルファイルシステムの issue ストア            | Agent と gh の境界を保証 _(v1.14)_     |
-| `issue-syncer.ts`      | gh → Issue Store 同期                              | リモートデータのローカル反映           |
-| `outbox-processor.ts`  | outbox ファイル読み込み・gh 実行                   | Agent の gh リクエストを検証 _(v1.14)_ |
-| `prioritizer.ts`       | 優先度ラベルの自動付与                             | batch 処理の順序最適化                 |
-| `queue.ts`             | issue のソート・キュー構築                         | 優先度順の処理を保証                   |
+| モジュール             | What                                                      | Why                                            |
+| ---------------------- | --------------------------------------------------------- | ---------------------------------------------- |
+| `workflow-loader.ts`   | workflow.json 読み込み・スキーマ検証・相互参照検証        | 設定漏れを起動前に排除                         |
+| `workflow-types.ts`    | Phase, Agent, Transition 等の型定義                       | 全モジュールの型安全性を保証                   |
+| `workflow-schema.json` | JSON Schema                                               | IDE 補完とバリデーション                       |
+| `label-resolver.ts`    | Label → Phase → Agent 解決                                | priority による優先度制御                      |
+| `phase-transition.ts`  | 遷移ロジック・ラベル変更計算・テンプレート展開            | Agent から遷移ロジックを分離                   |
+| `cycle-tracker.ts`     | Issue ごとの遷移回数追跡                                  | maxCycles でループ防止                         |
+| `dispatcher.ts`        | Agent 起動・完了ハンドリング                              | Runner 呼び出しのラッパー                      |
+| `github-client.ts`     | gh コマンドのラッパー                                     | gh アクセスを単一モジュールに集約              |
+| `orchestrator.ts`      | メインループ（全モジュール統合）                          | 単一 issue サイクル + batch 処理               |
+| `transaction-scope.ts` | Phase 遷移 saga の補償レジストリ (record/commit/rollback) | gh 複合操作を unit-atomic に保ち片側成功を阻止 |
+| `issue-store.ts`       | ローカルファイルシステムの issue ストア                   | Agent と gh の境界を保証 _(v1.14)_             |
+| `issue-syncer.ts`      | gh → Issue Store 同期                                     | リモートデータのローカル反映                   |
+| `outbox-processor.ts`  | outbox ファイル読み込み・gh 実行                          | Agent の gh リクエストを検証 _(v1.14)_         |
+| `prioritizer.ts`       | 優先度ラベルの自動付与                                    | batch 処理の順序最適化                         |
+| `queue.ts`             | issue のソート・キュー構築                                | 優先度順の処理を保証                           |
 
 ## Runner との境界
 

--- a/agents/orchestrator/file-github-client.ts
+++ b/agents/orchestrator/file-github-client.ts
@@ -123,6 +123,26 @@ export class FileGitHubClient implements GitHubClient {
     return this.#filterByCriteria(items, criteria);
   }
 
+  async listLabels(): Promise<string[]> {
+    // Repository-level label set is kept at `{storePath}/labels.json` as a
+    // JSON array of strings — independent of any single issue. When absent,
+    // the repository is treated as having no labels (empty set).
+    const path = `${this.#store.storePath}/labels.json`;
+    try {
+      const text = await Deno.readTextFile(path);
+      const parsed = JSON.parse(text);
+      if (!Array.isArray(parsed)) {
+        throw new Error(
+          `labels.json must contain a JSON array of strings, got ${typeof parsed}`,
+        );
+      }
+      return parsed.filter((x): x is string => typeof x === "string");
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return [];
+      throw error;
+    }
+  }
+
   async getIssueDetail(issueNumber: number): Promise<IssueDetail> {
     const meta = await this.#store.readMeta(issueNumber);
     const body = await this.#store.readBody(issueNumber);

--- a/agents/orchestrator/file-github-client.ts
+++ b/agents/orchestrator/file-github-client.ts
@@ -81,6 +81,32 @@ export class FileGitHubClient implements GitHubClient {
     await this.#store.updateMeta(issueNumber, { state: "closed" });
   }
 
+  async reopenIssue(issueNumber: number): Promise<void> {
+    await this.#store.updateMeta(issueNumber, { state: "open" });
+  }
+
+  async getRecentComments(
+    issueNumber: number,
+    limit: number,
+  ): Promise<{ body: string; createdAt: string }[]> {
+    if (limit <= 0) return [];
+    let comments: { id: string; body: string }[] = [];
+    try {
+      comments = await this.#store.readComments(issueNumber);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+      return [];
+    }
+    // Comment id is a millisecond epoch (see addIssueComment); use it as createdAt.
+    const withTimestamp = comments.map((c) => {
+      const ms = Number(c.id);
+      const createdAt = Number.isFinite(ms) ? new Date(ms).toISOString() : c.id;
+      return { body: c.body, createdAt };
+    });
+    withTimestamp.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    return withTimestamp.slice(0, limit);
+  }
+
   async listIssues(criteria: IssueCriteria): Promise<IssueListItem[]> {
     const numbers = await this.#store.listIssues();
     const items: IssueListItem[] = [];

--- a/agents/orchestrator/github-client.ts
+++ b/agents/orchestrator/github-client.ts
@@ -48,6 +48,7 @@ export interface GitHubClient {
     issueNumber: number,
     limit: number,
   ): Promise<{ body: string; createdAt: string }[]>;
+  listLabels(): Promise<string[]>;
 }
 
 /** Concrete implementation using `gh` CLI via Deno.Command. */
@@ -353,5 +354,27 @@ export class GhCliClient implements GitHubClient {
     if (stdout === "") return [];
 
     return JSON.parse(stdout) as { body: string; createdAt: string }[];
+  }
+
+  async listLabels(): Promise<string[]> {
+    const cmd = new Deno.Command("gh", {
+      args: ["label", "list", "--json", "name", "--limit", "1000"],
+      cwd: this.#cwd,
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await cmd.output();
+
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      throw new Error(`Failed to list labels: ${stderr}`);
+    }
+
+    const stdout = new TextDecoder().decode(output.stdout).trim();
+    if (stdout === "") return [];
+
+    const raw = JSON.parse(stdout) as { name: string }[];
+    return raw.map((l) => l.name);
   }
 }

--- a/agents/orchestrator/github-client.ts
+++ b/agents/orchestrator/github-client.ts
@@ -41,8 +41,13 @@ export interface GitHubClient {
   addIssueComment(issueNumber: number, comment: string): Promise<void>;
   createIssue(title: string, labels: string[], body: string): Promise<number>;
   closeIssue(issueNumber: number): Promise<void>;
+  reopenIssue(issueNumber: number): Promise<void>;
   listIssues(criteria: IssueCriteria): Promise<IssueListItem[]>;
   getIssueDetail(issueNumber: number): Promise<IssueDetail>;
+  getRecentComments(
+    issueNumber: number,
+    limit: number,
+  ): Promise<{ body: string; createdAt: string }[]>;
 }
 
 /** Concrete implementation using `gh` CLI via Deno.Command. */
@@ -195,6 +200,24 @@ export class GhCliClient implements GitHubClient {
     }
   }
 
+  async reopenIssue(issueNumber: number): Promise<void> {
+    const cmd = new Deno.Command("gh", {
+      args: ["issue", "reopen", String(issueNumber)],
+      cwd: this.#cwd,
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await cmd.output();
+
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      throw new Error(
+        `Failed to reopen issue #${issueNumber}: ${stderr}`,
+      );
+    }
+  }
+
   async listIssues(criteria: IssueCriteria): Promise<IssueListItem[]> {
     const args = [
       "issue",
@@ -294,5 +317,41 @@ export class GhCliClient implements GitHubClient {
       milestone: raw.milestone?.title ?? null,
       comments: raw.comments.map((c) => ({ id: c.id, body: c.body })),
     };
+  }
+
+  async getRecentComments(
+    issueNumber: number,
+    limit: number,
+  ): Promise<{ body: string; createdAt: string }[]> {
+    if (limit <= 0) return [];
+
+    const cmd = new Deno.Command("gh", {
+      args: [
+        "issue",
+        "view",
+        String(issueNumber),
+        "--json",
+        "comments",
+        "--jq",
+        `.comments | sort_by(.createdAt) | reverse | .[0:${limit}] | map({body, createdAt})`,
+      ],
+      cwd: this.#cwd,
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await cmd.output();
+
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      throw new Error(
+        `Failed to get recent comments for issue #${issueNumber}: ${stderr}`,
+      );
+    }
+
+    const stdout = new TextDecoder().decode(output.stdout).trim();
+    if (stdout === "") return [];
+
+    return JSON.parse(stdout) as { body: string; createdAt: string }[];
   }
 }

--- a/agents/orchestrator/integration_handoff_test.ts
+++ b/agents/orchestrator/integration_handoff_test.ts
@@ -132,6 +132,10 @@ class StubGitHubClient implements GitHubClient {
       comments: [],
     });
   }
+
+  listLabels(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
 }
 
 /** Stub dispatcher that records calls and returns a prepared outcome. */

--- a/agents/orchestrator/integration_handoff_test.ts
+++ b/agents/orchestrator/integration_handoff_test.ts
@@ -105,6 +105,17 @@ class StubGitHubClient implements GitHubClient {
     return Promise.resolve();
   }
 
+  reopenIssue(_issueNumber: number): Promise<void> {
+    return Promise.reject(new Error("reopenIssue not implemented"));
+  }
+
+  getRecentComments(
+    _issueNumber: number,
+    _limit: number,
+  ): Promise<{ body: string; createdAt: string }[]> {
+    return Promise.resolve([]);
+  }
+
   listIssues(_criteria: IssueCriteria): Promise<IssueListItem[]> {
     return Promise.resolve([]);
   }

--- a/agents/orchestrator/integration_test.ts
+++ b/agents/orchestrator/integration_test.ts
@@ -11,6 +11,10 @@ import { compensationMarker, Orchestrator } from "./orchestrator.ts";
 import { loadWorkflow } from "./workflow-loader.ts";
 import { IssueStore } from "./issue-store.ts";
 
+// Design §2.2: one phase transition produces one "add" call (T3) plus
+// one "remove" call (T4).
+const LABEL_CALLS_PER_TRANSITION = 2;
+
 // --- Shared workflow config fixture ---
 
 /** Valid workflow config for writing to temp files. */
@@ -398,7 +402,13 @@ Deno.test("integration: labelPrefix correctly namespaces labels", async () => {
 
     // Label updates are split into T3 (add) then T4 (remove) per design §2.2,
     // so each cycle yields two calls with only prefixed labels in each.
-    assertEquals(github.labelUpdates.length, 4);
+    const transitions = 2; // ready->review, review->done
+    assertEquals(
+      github.labelUpdates.length,
+      transitions * LABEL_CALLS_PER_TRANSITION,
+      "Expected 2 transitions × 2 label calls per transition (design §2.2) " +
+        "= 4 updates",
+    );
 
     // Cycle 1 T3: add "docs:review"
     assertEquals(github.labelUpdates[0].removed, []);
@@ -529,7 +539,13 @@ Deno.test("integration: no prefix preserves backward compatibility", async () =>
 
     // Label updates use bare labels (no prefix), split T3 (add) then T4
     // (remove) per design §2.2 — two calls per transition.
-    assertEquals(github.labelUpdates.length, 4);
+    const transitions = 2; // ready->review, review->done
+    assertEquals(
+      github.labelUpdates.length,
+      transitions * LABEL_CALLS_PER_TRANSITION,
+      "Expected 2 transitions × 2 label calls per transition (design §2.2) " +
+        "= 4 updates",
+    );
     assertEquals(github.labelUpdates[0].removed, []);
     assertEquals(github.labelUpdates[0].added, ["review"]);
     assertEquals(github.labelUpdates[1].removed, ["ready"]);

--- a/agents/orchestrator/integration_test.ts
+++ b/agents/orchestrator/integration_test.ts
@@ -199,6 +199,10 @@ class StubGitHubClient implements GitHubClient {
       comments: [],
     });
   }
+
+  listLabels(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
 }
 
 // =============================================================

--- a/agents/orchestrator/integration_test.ts
+++ b/agents/orchestrator/integration_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import type { WorkflowConfig } from "./workflow-types.ts";
 import type {
   GitHubClient,
@@ -7,8 +7,9 @@ import type {
   IssueListItem,
 } from "./github-client.ts";
 import { StubDispatcher } from "./dispatcher.ts";
-import { Orchestrator } from "./orchestrator.ts";
+import { compensationMarker, Orchestrator } from "./orchestrator.ts";
 import { loadWorkflow } from "./workflow-loader.ts";
+import { IssueStore } from "./issue-store.ts";
 
 // --- Shared workflow config fixture ---
 
@@ -61,11 +62,21 @@ class StubGitHubClient implements GitHubClient {
   #labelSequence: string[][];
   #callIndex = 0;
   #comments: { issueNumber: number; comment: string }[] = [];
+  #commentHistory: {
+    issueNumber: number;
+    body: string;
+    createdAt: string;
+  }[] = [];
   #labelUpdates: {
     issueNumber: number;
     removed: string[];
     added: string[];
   }[] = [];
+  #closedIssues: number[] = [];
+  #closeIssueCalls = 0;
+  // Fail the first N closeIssue calls; subsequent calls succeed. Defaults
+  // to 0 so existing tests keep their happy-path stub unchanged.
+  #closeIssueFailUntil = 0;
 
   constructor(labelSequence: string[][]) {
     this.#labelSequence = labelSequence;
@@ -93,6 +104,11 @@ class StubGitHubClient implements GitHubClient {
 
   addIssueComment(issueNumber: number, comment: string): Promise<void> {
     this.#comments.push({ issueNumber, comment });
+    this.#commentHistory.push({
+      issueNumber,
+      body: comment,
+      createdAt: new Date().toISOString(),
+    });
     return Promise.resolve();
   }
 
@@ -112,6 +128,23 @@ class StubGitHubClient implements GitHubClient {
     return this.#callIndex;
   }
 
+  get closedIssues(): number[] {
+    return this.#closedIssues;
+  }
+
+  get closeIssueCalls(): number {
+    return this.#closeIssueCalls;
+  }
+
+  /**
+   * Fail the first `n` closeIssue invocations; subsequent calls succeed.
+   * Used by the self-heal E2E test to model a transient T6 failure that
+   * recovers on the next run. Defaults to 0 (no injected failure).
+   */
+  setCloseIssueFailUntil(n: number): void {
+    this.#closeIssueFailUntil = n;
+  }
+
   createIssue(
     _title: string,
     _labels: string[],
@@ -120,8 +153,30 @@ class StubGitHubClient implements GitHubClient {
     return Promise.resolve(999);
   }
 
-  closeIssue(_issueNumber: number): Promise<void> {
+  closeIssue(issueNumber: number): Promise<void> {
+    this.#closeIssueCalls++;
+    if (this.#closeIssueCalls <= this.#closeIssueFailUntil) {
+      return Promise.reject(new Error("gh issue close failed (stubbed)"));
+    }
+    this.#closedIssues.push(issueNumber);
     return Promise.resolve();
+  }
+
+  reopenIssue(_issueNumber: number): Promise<void> {
+    return Promise.reject(new Error("reopenIssue not implemented"));
+  }
+
+  getRecentComments(
+    issueNumber: number,
+    limit: number,
+  ): Promise<{ body: string; createdAt: string }[]> {
+    if (limit <= 0) return Promise.resolve([]);
+    const filtered = this.#commentHistory
+      .filter((c) => c.issueNumber === issueNumber)
+      .slice(-limit)
+      .reverse()
+      .map((c) => ({ body: c.body, createdAt: c.createdAt }));
+    return Promise.resolve(filtered);
   }
 
   listIssues(_criteria: IssueCriteria): Promise<IssueListItem[]> {
@@ -341,17 +396,23 @@ Deno.test("integration: labelPrefix correctly namespaces labels", async () => {
     assertEquals(result.finalPhase, "complete");
     assertEquals(result.cycleCount, 2);
 
-    // Verify label updates use prefixed labels
-    assertEquals(github.labelUpdates.length, 2);
+    // Label updates are split into T3 (add) then T4 (remove) per design §2.2,
+    // so each cycle yields two calls with only prefixed labels in each.
+    assertEquals(github.labelUpdates.length, 4);
 
-    // Cycle 1: remove "docs:ready", add "docs:review"
-    // "bug" and "unrelated" should NOT be in labelsToRemove
-    assertEquals(github.labelUpdates[0].removed, ["docs:ready"]);
+    // Cycle 1 T3: add "docs:review"
+    assertEquals(github.labelUpdates[0].removed, []);
     assertEquals(github.labelUpdates[0].added, ["docs:review"]);
+    // Cycle 1 T4: remove "docs:ready" ("bug", "unrelated" are not touched)
+    assertEquals(github.labelUpdates[1].removed, ["docs:ready"]);
+    assertEquals(github.labelUpdates[1].added, []);
 
-    // Cycle 2: remove "docs:review", add "docs:done"
-    assertEquals(github.labelUpdates[1].removed, ["docs:review"]);
-    assertEquals(github.labelUpdates[1].added, ["docs:done"]);
+    // Cycle 2 T3: add "docs:done"
+    assertEquals(github.labelUpdates[2].removed, []);
+    assertEquals(github.labelUpdates[2].added, ["docs:done"]);
+    // Cycle 2 T4: remove "docs:review"
+    assertEquals(github.labelUpdates[3].removed, ["docs:review"]);
+    assertEquals(github.labelUpdates[3].added, []);
   } finally {
     await Deno.remove(tempDir, { recursive: true });
   }
@@ -398,9 +459,12 @@ Deno.test("integration: different prefixes do not cross-contaminate", async () =
     assertEquals(resultA.status, "completed");
     assertEquals(resultA.finalPhase, "complete");
     assertEquals(resultA.cycleCount, 2);
-    // Only docs-prefixed labels should be in updates
-    assertEquals(githubA.labelUpdates[0].removed, ["docs:ready"]);
+    // Only docs-prefixed labels should be in updates.
+    // T3 (add) precedes T4 (remove) per design §2.2.
+    assertEquals(githubA.labelUpdates[0].removed, []);
     assertEquals(githubA.labelUpdates[0].added, ["docs:review"]);
+    assertEquals(githubA.labelUpdates[1].removed, ["docs:ready"]);
+    assertEquals(githubA.labelUpdates[1].added, []);
 
     // Config B orchestrator should only resolve "impl:ready", ignore "docs:ready"
     const githubB = new StubGitHubClient([
@@ -419,9 +483,12 @@ Deno.test("integration: different prefixes do not cross-contaminate", async () =
     assertEquals(resultB.status, "completed");
     assertEquals(resultB.finalPhase, "complete");
     assertEquals(resultB.cycleCount, 2);
-    // Only impl-prefixed labels should be in updates
-    assertEquals(githubB.labelUpdates[0].removed, ["impl:ready"]);
+    // Only impl-prefixed labels should be in updates.
+    // T3 (add) precedes T4 (remove) per design §2.2.
+    assertEquals(githubB.labelUpdates[0].removed, []);
     assertEquals(githubB.labelUpdates[0].added, ["impl:review"]);
+    assertEquals(githubB.labelUpdates[1].removed, ["impl:ready"]);
+    assertEquals(githubB.labelUpdates[1].added, []);
   } finally {
     await Deno.remove(tempDir, { recursive: true });
   }
@@ -460,11 +527,17 @@ Deno.test("integration: no prefix preserves backward compatibility", async () =>
     assertEquals(result.finalPhase, "complete");
     assertEquals(result.cycleCount, 2);
 
-    // Label updates use bare labels (no prefix)
-    assertEquals(github.labelUpdates[0].removed, ["ready"]);
+    // Label updates use bare labels (no prefix), split T3 (add) then T4
+    // (remove) per design §2.2 — two calls per transition.
+    assertEquals(github.labelUpdates.length, 4);
+    assertEquals(github.labelUpdates[0].removed, []);
     assertEquals(github.labelUpdates[0].added, ["review"]);
-    assertEquals(github.labelUpdates[1].removed, ["review"]);
-    assertEquals(github.labelUpdates[1].added, ["done"]);
+    assertEquals(github.labelUpdates[1].removed, ["ready"]);
+    assertEquals(github.labelUpdates[1].added, []);
+    assertEquals(github.labelUpdates[2].removed, []);
+    assertEquals(github.labelUpdates[2].added, ["done"]);
+    assertEquals(github.labelUpdates[3].removed, ["review"]);
+    assertEquals(github.labelUpdates[3].added, []);
   } finally {
     await Deno.remove(tempDir, { recursive: true });
   }
@@ -502,3 +575,211 @@ Deno.test("integration: prefixed labels without matching prefix are ignored", as
     await Deno.remove(tempDir, { recursive: true });
   }
 });
+
+// =============================================================
+// Self-heal + idempotent compensation comment (design.md §3.3)
+// =============================================================
+
+/**
+ * Workflow config for the self-heal scenario.
+ *
+ * Derived from `createValidWorkflowJson()` with two adjustments required
+ * by the contract under test:
+ *   1. `reviewer.closeOnComplete = true` so reaching `complete` fires T6
+ *      (the irreversible side-effect whose failure the saga must catch).
+ *   2. `reviewer.closeCondition = "approved"` so only the happy reviewer
+ *      outcome triggers the close attempt — matches design §2.2 T6.
+ */
+function createSelfHealWorkflowConfig(): WorkflowConfig {
+  const json = createValidWorkflowJson() as unknown as WorkflowConfig;
+  // deno-lint-ignore no-explicit-any
+  const reviewer = json.agents.reviewer as any;
+  reviewer.closeOnComplete = true;
+  reviewer.closeCondition = "approved";
+  return json;
+}
+
+Deno.test(
+  "self-heal: T6 failure on cycle 2 recovers on cycle 3 with idempotent compensation comment",
+  async () => {
+    // Scenario (design.md §3.3 idempotency + orchestrator.ts T6 block):
+    //
+    //   Run 1 (store-backed, so tracker state + meta labels persist):
+    //     Cycle 1  ready  -> review     (T3/T4 commit; tracker count -> 1)
+    //     Cycle 2  review -> complete   T6 closeIssue throws
+    //                                   -> scope.rollback runs T4-comp
+    //                                      (re-add "review") then T3-comp
+    //                                      (remove "done"), posts a
+    //                                      marker-tagged compensation
+    //                                      comment, status="blocked".
+    //                                   tracker.record is NOT called, so
+    //                                   cycleSeq for this failing cycle
+    //                                   is tracker.getCount(1)+1 == 2.
+    //
+    //   Run 2 (same stub + store, closeIssue now succeeds):
+    //     Orchestrator re-loads the persisted tracker (count=1), reads
+    //     meta labels ["review"] (rollback left them intact), and
+    //     re-enters the same review -> complete transition. cycleSeq is
+    //     again count+1 == 2 — identical to run 1's failing cycle, which
+    //     is what makes compensationMarker(1, 2) a stable dedup key.
+    //     T6 now succeeds, tracker.record fires, commit clears the
+    //     pre-registered compensation before it can post. No new
+    //     compensation comment is posted — the pre-post getRecentComments
+    //     check would have caught it anyway, but the happy path never
+    //     reaches that code. Either way: comment count stays at 1.
+    //
+    // Pattern classification (test-design skill):
+    //   - Contract: "T6 failure -> next run self-heals to completed".
+    //   - Invariant: "compensation comment count per (issue, cycleSeq)
+    //                 remains exactly 1 across retries".
+
+    const tempDir = await Deno.makeTempDir();
+    try {
+      const config = createSelfHealWorkflowConfig();
+
+      // Pre-seed the store. Labels here are source-of-truth for the
+      // orchestrator when a store is wired in (it reads via
+      // store.readMeta, not github.getIssueLabels, at cycle start).
+      const storePath = `${tempDir}/store`;
+      const store = new IssueStore(storePath);
+      const issueNumber = 1;
+      const initialLabel = "ready";
+      await store.writeIssue({
+        meta: {
+          number: issueNumber,
+          title: "self-heal test",
+          labels: [initialLabel],
+          state: "open",
+          assignees: [],
+          milestone: null,
+        },
+        body: "",
+        comments: [],
+      });
+
+      // GitHub stub: closeIssue fails exactly once (run 1 cycle 2), then
+      // succeeds (run 2). Label sequence is only used as a fallback here
+      // since the store provides labels; we still supply one entry per
+      // possible read to keep the stub honest.
+      const github = new StubGitHubClient([
+        [initialLabel],
+        ["review"],
+        ["review"],
+        ["done"],
+      ]);
+      github.setCloseIssueFailUntil(1);
+
+      const dispatcher = new StubDispatcher({
+        iterator: "success",
+        reviewer: "approved",
+      });
+      const orchestrator = new Orchestrator(
+        config,
+        github,
+        dispatcher,
+        tempDir,
+      );
+
+      // =======================================================
+      // Run 1: cycle 1 succeeds, cycle 2 T6 fails -> blocked
+      // =======================================================
+      const first = await orchestrator.run(issueNumber, undefined, store);
+
+      assertEquals(
+        first.status,
+        "blocked",
+        "Precondition: T6 must have failed in run 1 for the self-heal " +
+          "scenario to apply. IF status != blocked THEN the invariants " +
+          "below are vacuous. Fix: orchestrator.ts T6 catch must set " +
+          "blocked + break.",
+      );
+      // Note: label rollback order and closeIssue call counts are the
+      // responsibility of transaction-scope_test.ts (LIFO contract). We
+      // do not re-assert them here to keep this test aligned with its
+      // stated invariants (self-heal reach + marker idempotency).
+
+      // I-2 setup: marker is posted exactly once in run 1. failingCycleSeq
+      // is derived from first.cycleCount + 1 (source of truth: tracker
+      // only records on full T3..T6 success, so the failing cycle's seq
+      // is count+1) — no bare literal.
+      const failingCycleSeq = first.cycleCount + 1;
+      const expectedMarker = compensationMarker(issueNumber, failingCycleSeq);
+      assertEquals(
+        github.comments.length,
+        1,
+        "Run 1 must post exactly one compensation comment (T6 failure " +
+          "-> rollback posts the pre-registered marker comment). " +
+          "Fix: orchestrator.ts T6 must scope.record() the compensation " +
+          "before invoking closeIssue so rollback() finds it.",
+      );
+      assertStringIncludes(
+        github.comments[0].comment,
+        expectedMarker,
+        `Compensation comment must embed marker "${expectedMarker}" ` +
+          `(from compensationMarker(${issueNumber}, ${failingCycleSeq})) ` +
+          "so a subsequent retry can detect+skip re-posting (design §3.3).",
+      );
+
+      // =======================================================
+      // Run 2: same issue, same stub+store -> self-heal
+      // =======================================================
+      const second = await orchestrator.run(issueNumber, undefined, store);
+
+      // I-1: Self-heal reachability.
+      assertEquals(
+        second.status,
+        "completed",
+        "I-1: IF the transient T6 failure has cleared THEN a second " +
+          "run on the same issue must reach completed. Fix: " +
+          "orchestrator.ts must re-read state from the store so the " +
+          "rollbacked transition is re-entered on retry.",
+      );
+      assertEquals(
+        second.finalPhase,
+        "complete",
+        "I-1: Self-heal must land on the terminal phase.",
+      );
+      // I-2: Idempotency invariant (design §3.3) — total compensation
+      // comment count across ALL runs remains 1. Run 2 must not post another
+      // marker comment even though the same phase transition is
+      // re-entered, because (a) the happy path commits the scope and
+      // clears the pre-registered compensation, and (b) even if it
+      // rolled back, getRecentComments would surface the marker and
+      // skip the duplicate post.
+      assertEquals(
+        github.comments.length,
+        1,
+        "Compensation comment count must stay at 1 across both runs. " +
+          "IF run 2's T6 succeeds THEN scope.commit() clears the " +
+          "pre-registered compensation before it can run. " +
+          "Fix: orchestrator.ts must register T6's compensation via " +
+          "scope.record (not scope.step's post-success factory) and " +
+          "call scope.commit() on the happy path so the marker post " +
+          "is skipped exactly when we want it skipped.",
+      );
+      assertStringIncludes(
+        github.comments[0].comment,
+        expectedMarker,
+        "I-2: The surviving marker must be run 1's — identity drift " +
+          "would defeat dedup. Fix: compensationMarker must be a pure " +
+          "function of (issueNumber, cycleSeq).",
+      );
+
+      // I-3: cycleSeq identity across runs — the precondition that
+      // makes marker-based dedup possible. Expressed as a relation
+      // (not specific counts) so the test exercises the invariant
+      // directly (skill: Decision Framework Q2 — relationship, not
+      // value).
+      assertEquals(
+        first.cycleCount + 1,
+        second.cycleCount,
+        "I-3: failing cycleSeq in run 1 (first.cycleCount + 1) must " +
+          "equal recovering cycleSeq in run 2 (second.cycleCount). " +
+          "Fix: tracker.record must fire only on full T3..T6 success, " +
+          "and the store must persist tracker state between runs.",
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+);

--- a/agents/orchestrator/issue-syncer_test.ts
+++ b/agents/orchestrator/issue-syncer_test.ts
@@ -59,6 +59,17 @@ class StubGitHubClient implements GitHubClient {
     return Promise.resolve();
   }
 
+  reopenIssue(_issueNumber: number): Promise<void> {
+    return Promise.reject(new Error("reopenIssue not implemented"));
+  }
+
+  getRecentComments(
+    _issueNumber: number,
+    _limit: number,
+  ): Promise<{ body: string; createdAt: string }[]> {
+    return Promise.resolve([]);
+  }
+
   listIssues(criteria: IssueCriteria): Promise<IssueListItem[]> {
     this.listIssuesCalls.push(criteria);
     return Promise.resolve(this.#issues);

--- a/agents/orchestrator/issue-syncer_test.ts
+++ b/agents/orchestrator/issue-syncer_test.ts
@@ -82,6 +82,10 @@ class StubGitHubClient implements GitHubClient {
     }
     return Promise.resolve(detail);
   }
+
+  listLabels(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
 }
 
 function makeDetail(num: number): IssueDetail {

--- a/agents/orchestrator/orchestrator.ts
+++ b/agents/orchestrator/orchestrator.ts
@@ -31,8 +31,21 @@ import { OutboxProcessor } from "./outbox-processor.ts";
 import { OrchestratorLogger } from "./orchestrator-logger.ts";
 import { BatchRunner } from "./batch-runner.ts";
 import { countdownDelay } from "./countdown.ts";
+import { TransactionScope } from "./transaction-scope.ts";
 
 export type { OrchestratorOptions, OrchestratorResult };
+
+/**
+ * Idempotency marker for T6 compensation comments. Both producer
+ * (rollback emits the comment) and consumer (pre-post dedup check via
+ * `getRecentComments`) must route through this factory so the string
+ * has a single source of truth. Used as idempotencyKey in the
+ * CompensationRegistry as well.
+ */
+export const compensationMarker = (
+  issueNumber: number,
+  cycleSeq: number,
+): string => `climpt-compensation:issue-${issueNumber}:cycle-${cycleSeq}`;
 
 export class Orchestrator {
   #config: WorkflowConfig;
@@ -480,122 +493,267 @@ export class Orchestrator {
         },
       );
 
-      // Step 10: Update labels
+      // Steps 10-12 (T1..T7): phase transition as a saga.
+      // Contract: tmp/transaction-rollback/investigation/design.md §2.2.
+      //   T1  pure plan (already computed above as labelsToRemove/labelsToAdd)
+      //   T2  snapshot preImage = currentLabels
+      //   T3  label add (compensation: remove the just-added labels)
+      //   T4  label remove (compensation: restore preImage labels)
+      //   T5  handoff comment (compensation: restore preImage labels — shares
+      //       idempotency key with T4 so future dedup can collapse both)
+      //   T6  close issue (compensation: post a marker-tagged comment so
+      //       humans can intervene; label preImage restore is optional per
+      //       §3.1 and elided here — next cycle's re-read self-heals labels)
+      //   T7  local persist (store.updateMeta + writeWorkflowState) —
+      //       best-effort, runs only after commit
+      //
+      // cycleTracker.record fires only on full T3..T6 success (before commit),
+      // closing a latent bug where S2 failures still recorded a transition.
+      const targetPhaseDef = this.#config.phases[targetPhase];
+      const isTerminal = targetPhaseDef?.type === "terminal";
+      const isBlocking = targetPhaseDef?.type === "blocking";
+      const closeIntent = !dryRun && isTerminal && agent.closeOnComplete &&
+        (agent.closeCondition === undefined ||
+          agent.closeCondition === dispatchResult.outcome);
+
       if (!dryRun) {
+        const preImage = [...currentLabels];
+        const cycleSeq = tracker.getCount(issueNumber) + 1;
+        const restoreLabelsKey = `restore-labels:${issueNumber}:${cycleSeq}`;
+        const marker = compensationMarker(issueNumber, cycleSeq);
+        const scope = new TransactionScope({ logger: log });
+
         try {
-          // deno-lint-ignore no-await-in-loop
-          await this.#github.updateIssueLabels(
+          // T3: add-labels (idempotent, reversible by removal)
+          if (labelsToAdd.length > 0) {
+            // deno-lint-ignore no-await-in-loop
+            await scope.step(
+              "add-labels",
+              () =>
+                this.#github.updateIssueLabels(issueNumber, [], labelsToAdd),
+              () => ({
+                label: "restore-labels",
+                idempotencyKey: restoreLabelsKey,
+                run: () =>
+                  this.#github.updateIssueLabels(
+                    issueNumber,
+                    labelsToAdd,
+                    [],
+                  ),
+              }),
+            );
+          }
+
+          // T4: remove-labels (reversing T4 restores preImage, which
+          //     re-adds anything we removed)
+          if (labelsToRemove.length > 0) {
+            // deno-lint-ignore no-await-in-loop
+            await scope.step(
+              "remove-labels",
+              () =>
+                this.#github.updateIssueLabels(
+                  issueNumber,
+                  labelsToRemove,
+                  [],
+                ),
+              () => ({
+                label: "restore-labels",
+                idempotencyKey: restoreLabelsKey,
+                run: () =>
+                  this.#github.updateIssueLabels(
+                    issueNumber,
+                    [],
+                    labelsToRemove,
+                  ),
+              }),
+            );
+          }
+
+          // T5: handoff comment. Compensation is label-restore (same key
+          //     as T4) — we rely on gh label ops being idempotent rather
+          //     than deduping compensations in TransactionScope.
+          if (this.#config.handoff) {
+            const handoff = new HandoffManager(this.#config.handoff);
+            // deno-lint-ignore no-await-in-loop
+            await scope.step(
+              "handoff-comment",
+              () =>
+                handoff.renderAndPost(
+                  this.#github,
+                  issueNumber,
+                  agentId,
+                  dispatchResult.outcome,
+                  { ...dispatchResult.handoffData },
+                ),
+              () => ({
+                label: "restore-labels",
+                idempotencyKey: restoreLabelsKey,
+                run: () =>
+                  this.#github.updateIssueLabels(
+                    issueNumber,
+                    labelsToAdd, // undo T3
+                    labelsToRemove, // undo T4
+                  ),
+              }),
+            );
+          }
+
+          // T6: close issue. Compensation posts a marker-tagged comment
+          //     requesting manual intervention; the marker is checked
+          //     against recent comments to make the compensation idempotent
+          //     across retries (design §3.3).
+          //
+          // Pre-register pattern (vs scope.step): TransactionScope.step()
+          // only records a compensation *after* the action resolves, so a
+          // step() whose action throws would never register its own
+          // compensation. T6 is the one step where compensation-on-failure
+          // is the entire contract (design §3.1 row 4), so we register the
+          // compensation *before* the action and rely on commit() clearing
+          // the stack on success / rollback() running it on failure.
+          if (closeIntent) {
+            scope.record({
+              label: "compensation-comment",
+              idempotencyKey: marker,
+              run: async () => {
+                try {
+                  const recent = await this.#github.getRecentComments(
+                    issueNumber,
+                    20,
+                  );
+                  if (recent.some((c) => c.body.includes(marker))) {
+                    return;
+                  }
+                } catch {
+                  // Marker lookup is best-effort; proceed to post.
+                }
+                const body = `⚠️ 自動遷移失敗: 手動確認をお願いします\n\n` +
+                  `phase 遷移 (${phaseId} → ${targetPhase}) で issue close ` +
+                  `に失敗しました。\nラベルは元に戻されています。\n\n` +
+                  `---\n<sub>🤖 ${marker}</sub>`;
+                await this.#github.addIssueComment(issueNumber, body);
+              },
+            });
+            // deno-lint-ignore no-await-in-loop
+            await this.#github.closeIssue(issueNumber);
+            issueClosed = true;
+            // deno-lint-ignore no-await-in-loop
+            await log.info(
+              `Closed issue #${issueNumber} (closeOnComplete, outcome="${dispatchResult.outcome}")`,
+              {
+                event: "issue_closed",
+                issueNumber,
+                agent: agentId,
+                outcome: dispatchResult.outcome,
+              },
+            );
+          }
+
+          // All T3..T6 steps succeeded. Record the cycle *before* commit
+          // so a crash between tracker.record and commit still surfaces
+          // the registered compensations on the next run. (commit()
+          // itself is synchronous in effect, so the window is negligible.)
+          tracker.record(
             issueNumber,
-            labelsToRemove,
-            labelsToAdd,
+            phaseId,
+            targetPhase,
+            agentId,
+            dispatchResult.outcome,
           );
+
+          // deno-lint-ignore no-await-in-loop
+          await scope.commit();
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           // deno-lint-ignore no-await-in-loop
           await log.warn(
-            `Failed to update labels for issue #${issueNumber}: ${msg}`,
-            { event: "label_update_failed", issueNumber, error: msg },
+            `Phase transition failed for issue #${issueNumber}: ${msg}`,
+            {
+              event: "phase_transition_failed",
+              issueNumber,
+              fromPhase: phaseId,
+              toPhase: targetPhase,
+              error: msg,
+            },
           );
-          // Label update failure is not fatal; continue to next cycle
+          // deno-lint-ignore no-await-in-loop
+          const report = await scope.rollback(error);
+          if (report.attempted > 0) {
+            // deno-lint-ignore no-await-in-loop
+            await log.warn(
+              `Compensation ran for issue #${issueNumber}: ` +
+                `${report.succeeded}/${report.attempted} succeeded` +
+                (report.partial ? " (partial)" : ""),
+              {
+                event: "compensation_ran",
+                issueNumber,
+                attempted: report.attempted,
+                succeeded: report.succeeded,
+                failed: report.failed.map((f) => ({
+                  label: f.label,
+                  idempotencyKey: f.idempotencyKey,
+                  error: f.error.message,
+                })),
+                partial: report.partial,
+              },
+            );
+          }
+          status = "blocked";
+          finalPhase = phaseId;
+          break;
+        } finally {
+          // Safety net: if neither commit nor rollback ran (e.g. exception
+          // escaped outside the try), ensure compensations are flushed.
+          if (!scope.isCommitted() && !scope.isRolledBack()) {
+            // deno-lint-ignore no-await-in-loop
+            await scope.rollback(new Error("scope not finalised"));
+          }
         }
 
-        // Step 10b: Update store meta to reflect new labels
+        // T7: local persist — best-effort. Next cycle re-reads labels from
+        // the source of truth (gh / store meta) so any divergence here is
+        // self-healed (design §3.1 row G5 / T7).
         if (store) {
-          const newLabels = currentLabels
+          const newLabels = preImage
             .filter((l) => !labelsToRemove.includes(l))
             .concat(labelsToAdd);
           try {
             // deno-lint-ignore no-await-in-loop
             await store.updateMeta(issueNumber, { labels: newLabels });
           } catch {
-            // Store update failure is not fatal
+            // non-fatal
+          }
+          try {
+            // deno-lint-ignore no-await-in-loop
+            await store.writeWorkflowState(
+              issueNumber,
+              tracker.toState(issueNumber, targetPhase),
+              wfId,
+            );
+          } catch {
+            // non-fatal
           }
         }
-      }
-
-      // Step 11: Record cycle
-      tracker.record(
-        issueNumber,
-        phaseId,
-        targetPhase,
-        agentId,
-        dispatchResult.outcome,
-      );
-
-      // Step 11b: Persist cycle tracker state
-      if (store) {
-        // deno-lint-ignore no-await-in-loop
-        await store.writeWorkflowState(
+      } else {
+        // dry-run: skip side-effects but still record the planned cycle so
+        // history reflects the intended transition.
+        tracker.record(
           issueNumber,
-          tracker.toState(issueNumber, targetPhase),
-          wfId,
-        );
-      }
-
-      // Step 12: Handoff comment
-      if (!dryRun && this.#config.handoff) {
-        const handoff = new HandoffManager(this.#config.handoff);
-        // deno-lint-ignore no-await-in-loop
-        await handoff.renderAndPost(
-          this.#github,
-          issueNumber,
+          phaseId,
+          targetPhase,
           agentId,
           dispatchResult.outcome,
-          { ...dispatchResult.handoffData },
         );
       }
 
       finalPhase = targetPhase;
 
-      // Check if target phase is terminal or blocking
-      const targetPhaseDef = this.#config.phases[targetPhase];
-      if (targetPhaseDef) {
-        if (targetPhaseDef.type === "terminal") {
-          status = "completed";
-
-          // closeOnComplete: close the GitHub issue when agent outcome leads to terminal
-          if (!dryRun && agent.closeOnComplete) {
-            const shouldClose = agent.closeCondition === undefined ||
-              agent.closeCondition === dispatchResult.outcome;
-            if (shouldClose) {
-              try {
-                // deno-lint-ignore no-await-in-loop
-                await this.#github.closeIssue(issueNumber);
-                issueClosed = true;
-                // deno-lint-ignore no-await-in-loop
-                await log.info(
-                  `Closed issue #${issueNumber} (closeOnComplete, outcome="${dispatchResult.outcome}")`,
-                  {
-                    event: "issue_closed",
-                    issueNumber,
-                    agent: agentId,
-                    outcome: dispatchResult.outcome,
-                  },
-                );
-              } catch (error) {
-                const msg = error instanceof Error
-                  ? error.message
-                  : String(error);
-                // deno-lint-ignore no-await-in-loop
-                await log.warn(
-                  `Failed to close issue #${issueNumber}: ${msg}`,
-                  {
-                    event: "issue_close_failed",
-                    issueNumber,
-                    error: msg,
-                  },
-                );
-                // Non-fatal: label transition succeeded, close is best-effort
-              }
-            }
-          }
-
-          break;
-        }
-        if (targetPhaseDef.type === "blocking") {
-          status = "blocked";
-          break;
-        }
+      if (isTerminal) {
+        status = "completed";
+        break;
+      }
+      if (isBlocking) {
+        status = "blocked";
+        break;
       }
 
       // Step 13: Countdown between cycles (skip in dryRun)

--- a/agents/orchestrator/orchestrator_test.ts
+++ b/agents/orchestrator/orchestrator_test.ts
@@ -12,6 +12,10 @@ import { StubDispatcher } from "./dispatcher.ts";
 import { compensationMarker, Orchestrator } from "./orchestrator.ts";
 import { IssueStore } from "./issue-store.ts";
 
+// Design §2.2: one phase transition produces one "add" call (T3) plus
+// one "remove" call (T4).
+const LABEL_CALLS_PER_TRANSITION = 2;
+
 // --- Test fixtures ---
 
 /** Minimal WorkflowConfig matching the design doc example. */
@@ -521,7 +525,13 @@ Deno.test("full cycle with labelPrefix: prefixed labels resolve and transition c
   assertEquals(result.cycleCount, 2);
   // Label updates are split into T3 (add-only) then T4 (remove-only) per
   // design §2.2, so each cycle produces two calls with prefixed labels.
-  assertEquals(github.labelUpdates.length, 4);
+  const transitions = 2; // ready->review, review->done
+  assertEquals(
+    github.labelUpdates.length,
+    transitions * LABEL_CALLS_PER_TRANSITION,
+    "Expected 2 transitions × 2 label calls per transition (design §2.2) " +
+      "= 4 updates",
+  );
   assertEquals(github.labelUpdates[0].removed, []);
   assertEquals(github.labelUpdates[0].added, ["wf:review"]);
   assertEquals(github.labelUpdates[1].removed, ["wf:ready"]);
@@ -763,11 +773,14 @@ Deno.test(
     //   [5] cycle 2 rollback T3 compensation  remove ["done"]
     // Assert length first so subsequent index accesses are non-vacuous.
     const labelUpdates = github.labelUpdates;
+    const forwardTransitions = 2; // cycle 1 ready->review, cycle 2 review->done
+    const compensations = 2; // cycle 2 T4-comp + T3-comp (LIFO)
     assertEquals(
       labelUpdates.length,
-      6,
-      "Expected 4 forward label ops (2 per cycle) plus 2 compensations " +
-        "for the cycle-2 T6 failure (LIFO T4-comp then T3-comp). " +
+      forwardTransitions * LABEL_CALLS_PER_TRANSITION + compensations,
+      "Expected 2 forward transitions × 2 label calls per transition " +
+        "(design §2.2) = 4, plus 2 compensations for the cycle-2 T6 " +
+        "failure (LIFO T4-comp then T3-comp) = 6 total. " +
         "Fix: orchestrator.ts T3/T4 must register compensations that " +
         "invert their forward ops, and scope.rollback() must run them.",
     );

--- a/agents/orchestrator/orchestrator_test.ts
+++ b/agents/orchestrator/orchestrator_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { ConfigError } from "../shared/errors/config-errors.ts";
 import { DEFAULT_ISSUE_STORE, type WorkflowConfig } from "./workflow-types.ts";
 import type {
@@ -9,7 +9,7 @@ import type {
 } from "./github-client.ts";
 import type { DispatchOutcome } from "./dispatcher.ts";
 import { StubDispatcher } from "./dispatcher.ts";
-import { Orchestrator } from "./orchestrator.ts";
+import { compensationMarker, Orchestrator } from "./orchestrator.ts";
 import { IssueStore } from "./issue-store.ts";
 
 // --- Test fixtures ---
@@ -70,6 +70,11 @@ class StubGitHubClient implements GitHubClient {
   #labelSequence: string[][];
   #callIndex = 0;
   #comments: { issueNumber: number; comment: string }[] = [];
+  #commentHistory: {
+    issueNumber: number;
+    body: string;
+    createdAt: string;
+  }[] = [];
   #labelUpdates: {
     issueNumber: number;
     removed: string[];
@@ -104,6 +109,11 @@ class StubGitHubClient implements GitHubClient {
 
   addIssueComment(issueNumber: number, comment: string): Promise<void> {
     this.#comments.push({ issueNumber, comment });
+    this.#commentHistory.push({
+      issueNumber,
+      body: comment,
+      createdAt: new Date().toISOString(),
+    });
     return Promise.resolve();
   }
 
@@ -137,6 +147,23 @@ class StubGitHubClient implements GitHubClient {
     }
     this.#closedIssues.push(issueNumber);
     return Promise.resolve();
+  }
+
+  reopenIssue(_issueNumber: number): Promise<void> {
+    return Promise.reject(new Error("reopenIssue not implemented"));
+  }
+
+  getRecentComments(
+    issueNumber: number,
+    limit: number,
+  ): Promise<{ body: string; createdAt: string }[]> {
+    if (limit <= 0) return Promise.resolve([]);
+    const filtered = this.#commentHistory
+      .filter((c) => c.issueNumber === issueNumber)
+      .slice(-limit)
+      .reverse()
+      .map((c) => ({ body: c.body, createdAt: c.createdAt }));
+    return Promise.resolve(filtered);
   }
 
   get closedIssues(): number[] {
@@ -492,12 +519,17 @@ Deno.test("full cycle with labelPrefix: prefixed labels resolve and transition c
   assertEquals(result.status, "completed");
   assertEquals(result.finalPhase, "complete");
   assertEquals(result.cycleCount, 2);
-  // Label updates should use prefixed labels
-  assertEquals(github.labelUpdates.length, 2);
-  assertEquals(github.labelUpdates[0].removed, ["wf:ready"]);
+  // Label updates are split into T3 (add-only) then T4 (remove-only) per
+  // design §2.2, so each cycle produces two calls with prefixed labels.
+  assertEquals(github.labelUpdates.length, 4);
+  assertEquals(github.labelUpdates[0].removed, []);
   assertEquals(github.labelUpdates[0].added, ["wf:review"]);
-  assertEquals(github.labelUpdates[1].removed, ["wf:review"]);
-  assertEquals(github.labelUpdates[1].added, ["wf:done"]);
+  assertEquals(github.labelUpdates[1].removed, ["wf:ready"]);
+  assertEquals(github.labelUpdates[1].added, []);
+  assertEquals(github.labelUpdates[2].removed, []);
+  assertEquals(github.labelUpdates[2].added, ["wf:done"]);
+  assertEquals(github.labelUpdates[3].removed, ["wf:review"]);
+  assertEquals(github.labelUpdates[3].added, []);
 });
 
 // === closeOnComplete Tests ===
@@ -670,31 +702,164 @@ Deno.test("closeOnComplete: early terminal detection does NOT trigger close", as
   assertEquals(result.issueClosed, undefined);
 });
 
-Deno.test("closeOnComplete: closeIssue failure is non-fatal", async () => {
-  const config = createCloseOnCompleteConfig();
-  const github = new StubGitHubClient([["ready"], ["review"], ["done"]]);
-  github.setCloseIssueShouldThrow(true);
-  const dispatcher = new StubDispatcher({
-    iterator: "success",
-    reviewer: "approved",
-  });
-  const orchestrator = new Orchestrator(config, github, dispatcher);
+Deno.test(
+  "closeOnComplete: closeIssue failure triggers compensation and marks cycle blocked",
+  async () => {
+    // Contract (design.md §1.3 G2, §2.2 T6, §3.1 T6):
+    //   T6 close is the last irreversible op. A close failure leaves the
+    //   issue with the terminal label but still open — exactly the A↔B gap
+    //   the saga exists to close. Therefore T6 failure is *fatal to the
+    //   cycle*: scope.rollback() restores labels to preImage (via the
+    //   LIFO T4→T3 compensations), status becomes "blocked", and
+    //   issueClosed stays undefined. The next run re-reads labels from
+    //   the source of truth and retries, so no implicit success is
+    //   reported to the caller.
+    const config = createCloseOnCompleteConfig();
+    // Cycle 1: ["ready"] -> iterator success -> "review"      (T3+T4 commit)
+    // Cycle 2: ["review"] -> reviewer approved -> "complete"
+    //          T3 add "done", T4 remove "review", T6 close throws ->
+    //          rollback runs T4 comp (re-add "review") then T3 comp
+    //          (remove "done"), restoring preImage ["review"].
+    const github = new StubGitHubClient([["ready"], ["review"], ["done"]]);
+    github.setCloseIssueShouldThrow(true);
+    const dispatcher = new StubDispatcher({
+      iterator: "success",
+      reviewer: "approved",
+    });
+    const orchestrator = new Orchestrator(config, github, dispatcher);
 
-  const result = await orchestrator.run(1);
+    const result = await orchestrator.run(1);
 
-  assertEquals(
-    result.status,
-    "completed",
-    "Workflow should complete even if closeIssue fails. " +
-      "Fix: orchestrator.ts closeOnComplete error must be non-fatal",
-  );
-  assertEquals(
-    result.issueClosed,
-    undefined,
-    "issueClosed should not be true when closeIssue threw",
-  );
-  assertEquals(github.closedIssues.length, 0);
-});
+    // --- Cycle-level contract ---
+    assertEquals(
+      result.status,
+      "blocked",
+      "T6 failure must mark the cycle blocked so the caller does not " +
+        "treat a half-applied transition as completed. " +
+        'Fix: orchestrator.ts T6 catch must set status="blocked" and break.',
+    );
+    assertEquals(
+      result.issueClosed,
+      undefined,
+      "issueClosed must stay undefined when closeIssue threw — the " +
+        "OrchestratorResult contract reserves true for verified close. " +
+        "Fix: orchestrator.ts must only set issueClosed=true inside the " +
+        "T6 step action *after* closeIssue resolves.",
+    );
+    assertEquals(
+      github.closedIssues.length,
+      0,
+      "StubGitHubClient only records successful closes; closeIssue threw, " +
+        "so no issue number should have been appended.",
+    );
+
+    // --- Rollback contract: preImage label restoration ---
+    // Expected labelUpdates sequence (index: side-effect):
+    //   [0] cycle 1 T3  add    ["review"]
+    //   [1] cycle 1 T4  remove ["ready"]
+    //   [2] cycle 2 T3  add    ["done"]
+    //   [3] cycle 2 T4  remove ["review"]
+    //   [4] cycle 2 rollback T4 compensation  add ["review"]
+    //   [5] cycle 2 rollback T3 compensation  remove ["done"]
+    // Assert length first so subsequent index accesses are non-vacuous.
+    const labelUpdates = github.labelUpdates;
+    assertEquals(
+      labelUpdates.length,
+      6,
+      "Expected 4 forward label ops (2 per cycle) plus 2 compensations " +
+        "for the cycle-2 T6 failure (LIFO T4-comp then T3-comp). " +
+        "Fix: orchestrator.ts T3/T4 must register compensations that " +
+        "invert their forward ops, and scope.rollback() must run them.",
+    );
+
+    // Forward ops — cycle 1 (no close failure here, commits normally).
+    assertEquals(labelUpdates[0].added, ["review"]);
+    assertEquals(labelUpdates[0].removed, []);
+    assertEquals(labelUpdates[1].added, []);
+    assertEquals(labelUpdates[1].removed, ["ready"]);
+
+    // Forward ops — cycle 2 up to the T6 throw.
+    assertEquals(labelUpdates[2].added, ["done"]);
+    assertEquals(labelUpdates[2].removed, []);
+    assertEquals(labelUpdates[3].added, []);
+    assertEquals(labelUpdates[3].removed, ["review"]);
+
+    // Compensations in LIFO order (T4 registered last → runs first).
+    assertEquals(
+      labelUpdates[4].added,
+      ["review"],
+      "T4 compensation must re-add the label that T4 removed so the " +
+        "issue returns to its preImage label set.",
+    );
+    assertEquals(labelUpdates[4].removed, []);
+    assertEquals(
+      labelUpdates[5].removed,
+      ["done"],
+      "T3 compensation must remove the label that T3 added so no stale " +
+        "terminal label is left on the still-open issue (G2 closure).",
+    );
+    assertEquals(labelUpdates[5].added, []);
+
+    // --- Rollback contract: T6 compensation comment is posted ---
+    // design.md §3.1 row 4 + §3.3: on T6 (close) failure the orchestrator
+    // must post a marker-tagged "自動遷移失敗" comment so a human can
+    // intervene. The marker returned by compensationMarker() (visible
+    // `<sub>` footer signature) makes the compensation idempotent across
+    // retries.
+    //
+    // Implementation note: this works because orchestrator.ts pre-registers
+    // the compensation on scope *before* invoking closeIssue (scope.record
+    // rather than scope.step's post-success factory). On success, commit()
+    // clears the stack before the compensation can run; on failure,
+    // rollback() runs it LIFO-first. The test config has no handoff, so
+    // cycle 1 never posts anything — cycle 2 is the sole source of the
+    // single expected comment.
+    // Assert length first so subsequent index access is non-vacuous.
+    assertEquals(
+      github.comments.length,
+      1,
+      "T6 close failed, so the pre-registered compensation comment must " +
+        "have been posted during rollback(). " +
+        "Fix: orchestrator.ts T6 must call scope.record(compCommentReg) " +
+        "before invoking closeIssue so rollback() can find the " +
+        "compensation even when the action itself threw.",
+    );
+    const comp = github.comments[0];
+    assertEquals(
+      comp.issueNumber,
+      1,
+      "Compensation comment must be addressed to the same issue whose " +
+        "close failed.",
+    );
+    // Marker is derived from orchestrator.ts's exported factory so the
+    // test tracks the single source of truth. issueNumber=1, cycleSeq=2
+    // (cycle 2 is the failing cycle).
+    const expectedMarker = compensationMarker(1, 2);
+    assertStringIncludes(
+      comp.comment,
+      expectedMarker,
+      `Compensation comment body must embed the deterministic marker ` +
+        `"${expectedMarker}" produced by compensationMarker(1, 2) so a ` +
+        `retry can detect and skip re-posting (design §3.3).`,
+    );
+    // Visible footer format: user-facing warning header + <sub> signature
+    // line. Both strings are load-bearing for the "HTML comment → visible
+    // footer" contract change; if either disappears the marker may still
+    // match but the user-visibility guarantee is lost.
+    assertStringIncludes(
+      comp.comment,
+      "⚠️ 自動遷移失敗",
+      "Visible warning header must be present so the comment is readable " +
+        "in the GitHub UI (not hidden in an HTML comment).",
+    );
+    assertStringIncludes(
+      comp.comment,
+      `<sub>🤖 ${expectedMarker}</sub>`,
+      "Marker must be embedded in a <sub> footer so it is visible to " +
+        "users while remaining greppable for idempotency checks.",
+    );
+  },
+);
 
 Deno.test("closeOnComplete: closeCondition filters even when target is terminal", async () => {
   // Validator where both outcomes route to terminal, but closeCondition is "approved"
@@ -806,6 +971,17 @@ class BatchStubGitHubClient implements GitHubClient {
 
   closeIssue(_issueNumber: number): Promise<void> {
     return Promise.resolve();
+  }
+
+  reopenIssue(_issueNumber: number): Promise<void> {
+    return Promise.reject(new Error("reopenIssue not implemented"));
+  }
+
+  getRecentComments(
+    _issueNumber: number,
+    _limit: number,
+  ): Promise<{ body: string; createdAt: string }[]> {
+    return Promise.resolve([]);
   }
 
   listIssues(criteria: IssueCriteria): Promise<IssueListItem[]> {

--- a/agents/orchestrator/orchestrator_test.ts
+++ b/agents/orchestrator/orchestrator_test.ts
@@ -194,6 +194,10 @@ class StubGitHubClient implements GitHubClient {
       comments: [],
     });
   }
+
+  listLabels(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
 }
 
 // --- Tests ---
@@ -1008,6 +1012,10 @@ class BatchStubGitHubClient implements GitHubClient {
       return Promise.reject(new Error(`No detail for #${issueNumber}`));
     }
     return Promise.resolve(detail);
+  }
+
+  listLabels(): Promise<string[]> {
+    return Promise.resolve([]);
   }
 }
 

--- a/agents/orchestrator/outbox-processor_test.ts
+++ b/agents/orchestrator/outbox-processor_test.ts
@@ -77,6 +77,17 @@ class StubGitHubClient implements GitHubClient {
     await Promise.resolve();
   }
 
+  reopenIssue(_issueNumber: number): Promise<void> {
+    return Promise.reject(new Error("reopenIssue not implemented"));
+  }
+
+  getRecentComments(
+    _issueNumber: number,
+    _limit: number,
+  ): Promise<{ body: string; createdAt: string }[]> {
+    return Promise.resolve([]);
+  }
+
   async listIssues(_criteria: IssueCriteria): Promise<IssueListItem[]> {
     return await Promise.resolve([]);
   }

--- a/agents/orchestrator/outbox-processor_test.ts
+++ b/agents/orchestrator/outbox-processor_test.ts
@@ -104,6 +104,10 @@ class StubGitHubClient implements GitHubClient {
       comments: [],
     });
   }
+
+  async listLabels(): Promise<string[]> {
+    return await Promise.resolve([]);
+  }
 }
 
 /** Create a temp IssueStore with outbox directory ready. */

--- a/agents/orchestrator/transaction-scope.ts
+++ b/agents/orchestrator/transaction-scope.ts
@@ -125,6 +125,11 @@ export class TransactionScope {
 
     for (const compensation of pending) {
       try {
+        // Saga compensations must run in strict LIFO order; later
+        // compensations may depend on the side effects of earlier ones
+        // being already reverted. Parallel execution would break that
+        // ordering contract.
+        // deno-lint-ignore no-await-in-loop
         await compensation.run();
         succeeded += 1;
       } catch (error) {
@@ -135,6 +140,10 @@ export class TransactionScope {
           error: err,
         });
         try {
+          // Same LIFO-ordering rationale: log entry for a failed
+          // compensation must be flushed before the next compensation
+          // runs so operators see the sequence in correct order.
+          // deno-lint-ignore no-await-in-loop
           await this.#logger.warn(
             `TransactionScope compensation "${compensation.label}" failed: ${err.message}`,
             {
@@ -184,7 +193,7 @@ function causeMessage(cause: unknown): string {
 }
 
 const consoleWarnLogger: TransactionLogger = {
-  warn(message, metadata) {
+  warn(message: string, metadata?: Record<string, unknown>): Promise<void> {
     // deno-lint-ignore no-console
     console.warn(`[transaction-scope] ${message}`, metadata ?? {});
     return Promise.resolve();

--- a/agents/orchestrator/transaction-scope.ts
+++ b/agents/orchestrator/transaction-scope.ts
@@ -1,0 +1,192 @@
+/**
+ * TransactionScope: saga-style compensation registry for phase-transition
+ * side-effects (label add/remove, handoff comment, issue close).
+ *
+ * Usage pattern:
+ *   const tx = new TransactionScope({ logger });
+ *   try {
+ *     await tx.step("label-add", () => gh.addLabels(...), () => ({
+ *       label: "restore-labels-add",
+ *       idempotencyKey: `issue-${n}:labels-add:${cycleSeq}`,
+ *       run: () => gh.removeLabels(...),
+ *     }));
+ *     await tx.step("label-remove", ...);
+ *     await tx.commit();
+ *   } catch (cause) {
+ *     const report = await tx.rollback(cause);
+ *     // surface report.partial / report.failed to caller for logging
+ *   }
+ *
+ * Design contract (see tmp/transaction-rollback/investigation/design.md §4.3):
+ *   - LIFO compensation order (reverse of registration).
+ *   - Compensations are only recorded on step success.
+ *   - rollback() is best-effort: each compensation failure is captured in
+ *     CompensationReport.failed; the method itself never throws.
+ *   - commit() clears the stack; post-commit record()/rollback() are no-ops.
+ *   - Retry logic lives inside each Compensation.run, not in this class.
+ *   - idempotencyKey is opaque metadata for the caller (e.g. to embed a
+ *     deterministic marker in a compensation comment); this class only
+ *     stores it so logs/reports can correlate.
+ */
+
+export interface Compensation {
+  readonly label: string;
+  readonly idempotencyKey: string;
+  readonly run: () => Promise<void>;
+}
+
+export interface CompensationFailure {
+  readonly label: string;
+  readonly idempotencyKey: string;
+  readonly error: Error;
+}
+
+export interface CompensationReport {
+  readonly attempted: number;
+  readonly succeeded: number;
+  readonly failed: ReadonlyArray<CompensationFailure>;
+  readonly partial: boolean;
+}
+
+export interface TransactionLogger {
+  warn(message: string, metadata?: Record<string, unknown>): Promise<void>;
+}
+
+export interface TransactionScopeOptions {
+  logger?: TransactionLogger;
+}
+
+type State = "open" | "committed" | "rolledBack";
+
+export class TransactionScope {
+  readonly #stack: Compensation[] = [];
+  readonly #logger: TransactionLogger;
+  #state: State = "open";
+
+  constructor(options: TransactionScopeOptions = {}) {
+    this.#logger = options.logger ?? consoleWarnLogger;
+  }
+
+  /** Push a compensation onto the LIFO stack. No-op once committed or rolled back. */
+  record(compensation: Compensation): void {
+    if (this.#state !== "open") return;
+    this.#stack.push(compensation);
+  }
+
+  /**
+   * Execute `action`; on success, register the compensation returned by
+   * `compensationFactory` (if provided). On failure, rethrow without
+   * registering — the caller is expected to invoke `rollback()`.
+   *
+   * `compensationFactory` is only invoked after `action` resolves, so it
+   * can safely reference post-action state.
+   */
+  async step(
+    label: string,
+    action: () => Promise<void>,
+    compensationFactory?: () => Compensation,
+  ): Promise<void> {
+    if (this.#state !== "open") {
+      throw new Error(
+        `TransactionScope.step("${label}") called after ${this.#state}`,
+      );
+    }
+    await action();
+    if (compensationFactory) {
+      this.#stack.push(compensationFactory());
+    }
+  }
+
+  /** Discard compensations; transition to committed. Idempotent. */
+  commit(): Promise<void> {
+    if (this.#state === "open") {
+      this.#stack.length = 0;
+      this.#state = "committed";
+    }
+    return Promise.resolve();
+  }
+
+  /**
+   * Execute all recorded compensations in LIFO order. Each compensation is
+   * best-effort: exceptions are caught and collected into the returned
+   * report. The method itself never throws.
+   *
+   * No-op once committed or already rolled back — returns an empty report.
+   */
+  async rollback(cause: unknown): Promise<CompensationReport> {
+    if (this.#state !== "open") {
+      return emptyReport();
+    }
+    this.#state = "rolledBack";
+
+    const pending = this.#stack.splice(0, this.#stack.length).reverse();
+    const failed: CompensationFailure[] = [];
+    let succeeded = 0;
+
+    for (const compensation of pending) {
+      try {
+        await compensation.run();
+        succeeded += 1;
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        failed.push({
+          label: compensation.label,
+          idempotencyKey: compensation.idempotencyKey,
+          error: err,
+        });
+        try {
+          await this.#logger.warn(
+            `TransactionScope compensation "${compensation.label}" failed: ${err.message}`,
+            {
+              event: "compensation_failed",
+              label: compensation.label,
+              idempotencyKey: compensation.idempotencyKey,
+              error: err.message,
+              cause: causeMessage(cause),
+            },
+          );
+        } catch {
+          // logger itself must not break rollback
+        }
+      }
+    }
+
+    return {
+      attempted: pending.length,
+      succeeded,
+      failed,
+      partial: succeeded < pending.length,
+    };
+  }
+
+  isCommitted(): boolean {
+    return this.#state === "committed";
+  }
+
+  isRolledBack(): boolean {
+    return this.#state === "rolledBack";
+  }
+
+  /** Number of compensations currently queued. Exposed for diagnostics only. */
+  pendingCount(): number {
+    return this.#stack.length;
+  }
+}
+
+function emptyReport(): CompensationReport {
+  return { attempted: 0, succeeded: 0, failed: [], partial: false };
+}
+
+function causeMessage(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  if (cause === undefined) return "";
+  return String(cause);
+}
+
+const consoleWarnLogger: TransactionLogger = {
+  warn(message, metadata) {
+    // deno-lint-ignore no-console
+    console.warn(`[transaction-scope] ${message}`, metadata ?? {});
+    return Promise.resolve();
+  },
+};

--- a/agents/orchestrator/transaction-scope_test.ts
+++ b/agents/orchestrator/transaction-scope_test.ts
@@ -1,0 +1,606 @@
+/**
+ * Unit tests for TransactionScope.
+ *
+ * Design reference:
+ *   tmp/transaction-rollback/investigation/design.md §4.4
+ *
+ * The six enumerated observation points from the design doc are covered
+ * (T3..T6 failure scenarios, rollback idempotency, partial compensation
+ * failure). Additional tests cover the class-level contracts stated in
+ * the module-level doc of transaction-scope.ts:
+ *   - record() is a no-op after commit or rollback
+ *   - rollback() after commit returns an empty report and never throws
+ *   - compensationFactory is only invoked after step action success
+ *   - LIFO order is honored across 3+ registered compensations
+ *   - TransactionLogger.warn is invoked when a compensation throws
+ *
+ * Testing style:
+ *   - Expected labels are held in arrays declared inside each test and
+ *     are the single source of truth that both the production call and
+ *     the assertion reference; no magic literals in assertions.
+ *   - Non-vacuity: every rollback test first asserts that at least one
+ *     compensation was attempted before inspecting order, so an
+ *     accidentally-empty stack cannot pass silently.
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+import {
+  type Compensation,
+  type CompensationReport,
+  type TransactionLogger,
+  TransactionScope,
+} from "./transaction-scope.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+interface RecordingLogger extends TransactionLogger {
+  readonly calls: Array<
+    { message: string; metadata?: Record<string, unknown> }
+  >;
+}
+
+function newRecordingLogger(): RecordingLogger {
+  const calls: Array<{ message: string; metadata?: Record<string, unknown> }> =
+    [];
+  return {
+    calls,
+    warn(message, metadata) {
+      calls.push({ message, metadata });
+      return Promise.resolve();
+    },
+  };
+}
+
+/**
+ * Build a compensation whose run() appends its label to `executionLog`.
+ * idempotencyKey is deterministic so assertions can correlate.
+ */
+function makeCompensation(
+  label: string,
+  executionLog: string[],
+  opts: { throwOnRun?: Error } = {},
+): Compensation {
+  return {
+    label,
+    idempotencyKey: `key:${label}`,
+    run: () => {
+      executionLog.push(label);
+      if (opts.throwOnRun) {
+        return Promise.reject(opts.throwOnRun);
+      }
+      return Promise.resolve();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// §4.4 test case 1 — T3 fail: empty registry rollback is a no-op
+// ---------------------------------------------------------------------------
+
+Deno.test("T3 fail: rollback with empty registry executes nothing", async () => {
+  const tx = new TransactionScope();
+
+  // Simulate T3 (first label-add) throwing before any compensation is recorded.
+  const t3Error = new Error("T3 label-add failed");
+  await assertRejects(
+    () =>
+      tx.step(
+        "label-add",
+        () => Promise.reject(t3Error),
+        () => {
+          throw new Error(
+            "compensationFactory must NOT be invoked when action fails",
+          );
+        },
+      ),
+    Error,
+    "T3 label-add failed",
+  );
+
+  assertEquals(
+    tx.pendingCount(),
+    0,
+    "no compensations should be recorded when the action itself threw",
+  );
+
+  const report = await tx.rollback(t3Error);
+  assertEquals(report.attempted, 0, "nothing was recorded, nothing to run");
+  assertEquals(report.succeeded, 0);
+  assertEquals(report.failed.length, 0);
+  assertEquals(report.partial, false, "empty rollback is not partial");
+  assertEquals(tx.isRolledBack(), true);
+});
+
+// ---------------------------------------------------------------------------
+// §4.4 test case 2 — T4 fail: T3 compensation (restore-labels-remove) runs
+// ---------------------------------------------------------------------------
+
+Deno.test("T4 fail: T3 compensation is executed during rollback", async () => {
+  const tx = new TransactionScope();
+  const executionLog: string[] = [];
+  const expectedOrder = ["restore-labels-remove"];
+
+  // T3 (label-add) succeeds and registers its inverse.
+  await tx.step(
+    "label-add",
+    () => Promise.resolve(),
+    () => makeCompensation("restore-labels-remove", executionLog),
+  );
+  assertEquals(
+    tx.pendingCount(),
+    1,
+    "T3 success must leave exactly one compensation on the stack",
+  );
+
+  // T4 (label-remove) fails; caller is expected to rollback.
+  const t4Error = new Error("T4 label-remove failed");
+  await assertRejects(
+    () => tx.step("label-remove", () => Promise.reject(t4Error)),
+    Error,
+    "T4 label-remove failed",
+  );
+
+  const report = await tx.rollback(t4Error);
+  assertEquals(
+    executionLog.length,
+    expectedOrder.length,
+    "exactly the recorded compensation must be attempted",
+  );
+  assertEquals(executionLog, expectedOrder);
+  assertEquals(report.attempted, expectedOrder.length);
+  assertEquals(report.succeeded, expectedOrder.length);
+  assertEquals(report.partial, false);
+  assertEquals(tx.pendingCount(), 0, "stack must be drained after rollback");
+});
+
+// ---------------------------------------------------------------------------
+// §4.4 test case 3 — T5 fail: T3 + T4 compensations run in LIFO order
+// ---------------------------------------------------------------------------
+
+Deno.test("T5 fail: T4 then T3 compensations execute in LIFO order", async () => {
+  const tx = new TransactionScope();
+  const executionLog: string[] = [];
+  // LIFO: the compensation registered last (T4) runs first.
+  const expectedOrder = ["restore-labels-add", "restore-labels-remove"];
+
+  await tx.step(
+    "label-add",
+    () => Promise.resolve(),
+    () => makeCompensation("restore-labels-remove", executionLog),
+  );
+  await tx.step(
+    "label-remove",
+    () => Promise.resolve(),
+    () => makeCompensation("restore-labels-add", executionLog),
+  );
+  assertEquals(tx.pendingCount(), 2, "two compensations must be recorded");
+
+  const t5Error = new Error("T5 comment failed");
+  await assertRejects(
+    () => tx.step("handoff-comment", () => Promise.reject(t5Error)),
+    Error,
+    "T5 comment failed",
+  );
+
+  const report = await tx.rollback(t5Error);
+  assertEquals(
+    executionLog.length,
+    expectedOrder.length,
+    "every recorded compensation must be attempted",
+  );
+  assertEquals(
+    executionLog,
+    expectedOrder,
+    "LIFO order must be reverse of registration",
+  );
+  assertEquals(report.attempted, expectedOrder.length);
+  assertEquals(report.succeeded, expectedOrder.length);
+  assertEquals(report.partial, false);
+});
+
+// ---------------------------------------------------------------------------
+// §4.4 test case 4 — T6 fail: three compensations (including comment) run LIFO
+// ---------------------------------------------------------------------------
+
+Deno.test("T6 fail: three compensations run in LIFO including compensation comment", async () => {
+  const tx = new TransactionScope();
+  const executionLog: string[] = [];
+  // Registration order: T3-inverse, T4-inverse, T5-inverse (comment).
+  // Expected rollback order is the reverse.
+  const registrationOrder = [
+    "restore-labels-remove", // T3 inverse
+    "restore-labels-add", // T4 inverse
+    "compensation-comment", // T5 inverse
+  ];
+  const expectedOrder = [...registrationOrder].reverse();
+
+  await tx.step(
+    "label-add",
+    () => Promise.resolve(),
+    () => makeCompensation(registrationOrder[0], executionLog),
+  );
+  await tx.step(
+    "label-remove",
+    () => Promise.resolve(),
+    () => makeCompensation(registrationOrder[1], executionLog),
+  );
+  await tx.step(
+    "handoff-comment",
+    () => Promise.resolve(),
+    () => makeCompensation(registrationOrder[2], executionLog),
+  );
+  assertEquals(
+    tx.pendingCount(),
+    registrationOrder.length,
+    "all three compensations must be recorded before T6",
+  );
+
+  const t6Error = new Error("T6 close failed");
+  await assertRejects(
+    () => tx.step("close-issue", () => Promise.reject(t6Error)),
+    Error,
+    "T6 close failed",
+  );
+
+  const report = await tx.rollback(t6Error);
+  assertEquals(
+    executionLog.length,
+    expectedOrder.length,
+    "non-vacuity: every compensation must be attempted",
+  );
+  assertEquals(executionLog, expectedOrder);
+  assertEquals(report.attempted, expectedOrder.length);
+  assertEquals(report.succeeded, expectedOrder.length);
+  assertEquals(report.partial, false);
+});
+
+// ---------------------------------------------------------------------------
+// §4.4 test case 5 — rollback idempotency
+// ---------------------------------------------------------------------------
+
+Deno.test("rollback idempotency: second rollback is a no-op", async () => {
+  const tx = new TransactionScope();
+  const executionLog: string[] = [];
+  const expectedFirstRun = ["restore-labels-add", "restore-labels-remove"];
+
+  await tx.step(
+    "label-add",
+    () => Promise.resolve(),
+    () => makeCompensation("restore-labels-remove", executionLog),
+  );
+  await tx.step(
+    "label-remove",
+    () => Promise.resolve(),
+    () => makeCompensation("restore-labels-add", executionLog),
+  );
+
+  const cause = new Error("some failure");
+  const first = await tx.rollback(cause);
+  assertEquals(first.attempted, expectedFirstRun.length);
+  assertEquals(executionLog, expectedFirstRun);
+  assertEquals(tx.isRolledBack(), true);
+  assertEquals(tx.pendingCount(), 0);
+
+  const second = await tx.rollback(cause);
+  assertEquals(
+    second.attempted,
+    0,
+    "rollback after rolledBack must attempt nothing",
+  );
+  assertEquals(second.succeeded, 0);
+  assertEquals(second.failed.length, 0);
+  assertEquals(second.partial, false);
+  assertEquals(
+    executionLog,
+    expectedFirstRun,
+    "execution log must not grow on the second rollback",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// §4.4 test case 6 — compensation itself fails
+// ---------------------------------------------------------------------------
+
+Deno.test("compensation failure: other compensations still run and report.partial=true", async () => {
+  const logger = newRecordingLogger();
+  const tx = new TransactionScope({ logger });
+  const executionLog: string[] = [];
+
+  const failingLabel = "restore-labels-add";
+  const survivingLabel = "restore-labels-remove";
+  const compensationError = new Error("gh remove-label network error");
+
+  // Registration order: surviving (T3), failing (T4).
+  // LIFO rollback: failing runs first, then surviving.
+  await tx.step(
+    "label-add",
+    () => Promise.resolve(),
+    () => makeCompensation(survivingLabel, executionLog),
+  );
+  await tx.step(
+    "label-remove",
+    () => Promise.resolve(),
+    () =>
+      makeCompensation(failingLabel, executionLog, {
+        throwOnRun: compensationError,
+      }),
+  );
+
+  const cause = new Error("T5 failed");
+  const report: CompensationReport = await tx.rollback(cause);
+
+  assertEquals(
+    executionLog,
+    [failingLabel, survivingLabel],
+    "both compensations must run in LIFO despite the first throwing",
+  );
+  assertEquals(report.attempted, 2);
+  assertEquals(report.succeeded, 1);
+  assertEquals(report.failed.length, 1);
+  assertEquals(report.failed[0].label, failingLabel);
+  assertEquals(report.failed[0].idempotencyKey, `key:${failingLabel}`);
+  assertEquals(report.failed[0].error, compensationError);
+  assertEquals(
+    report.partial,
+    true,
+    "succeeded < attempted ⇒ partial must be true",
+  );
+
+  // Logger contract: warn is invoked exactly once — for the failing compensation.
+  assertEquals(
+    logger.calls.length,
+    1,
+    "TransactionLogger.warn must be called for each compensation failure",
+  );
+  const call = logger.calls[0];
+  assertEquals(
+    call.metadata?.event,
+    "compensation_failed",
+    "warn metadata must tag event=compensation_failed",
+  );
+  assertEquals(call.metadata?.label, failingLabel);
+  assertEquals(call.metadata?.idempotencyKey, `key:${failingLabel}`);
+  assertEquals(call.metadata?.error, compensationError.message);
+  assertEquals(
+    call.metadata?.cause,
+    cause.message,
+    "cause message must be propagated into warn metadata",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Additional contract tests
+// ---------------------------------------------------------------------------
+
+Deno.test("post-commit record() is a silent no-op", async () => {
+  const tx = new TransactionScope();
+  const executionLog: string[] = [];
+
+  await tx.step(
+    "label-add",
+    () => Promise.resolve(),
+    () => makeCompensation("restore-labels-remove", executionLog),
+  );
+  await tx.commit();
+  assertEquals(tx.isCommitted(), true);
+  assertEquals(
+    tx.pendingCount(),
+    0,
+    "commit must clear the compensation stack",
+  );
+
+  // Contract: record() after commit returns without throwing and is a no-op.
+  tx.record(makeCompensation("late-registration", executionLog));
+  assertEquals(
+    tx.pendingCount(),
+    0,
+    "record() after commit must not grow the stack",
+  );
+  assertEquals(
+    executionLog.length,
+    0,
+    "no compensation should ever have run",
+  );
+});
+
+Deno.test("post-commit rollback() returns an empty report and never throws", async () => {
+  const tx = new TransactionScope();
+  const executionLog: string[] = [];
+
+  await tx.step(
+    "label-add",
+    () => Promise.resolve(),
+    () => makeCompensation("restore-labels-remove", executionLog),
+  );
+  await tx.commit();
+
+  const report = await tx.rollback(new Error("ignored after commit"));
+  assertEquals(report.attempted, 0);
+  assertEquals(report.succeeded, 0);
+  assertEquals(report.failed.length, 0);
+  assertEquals(report.partial, false);
+  assertEquals(
+    executionLog.length,
+    0,
+    "commit must prevent any compensation from running on later rollback",
+  );
+  assertEquals(
+    tx.isCommitted(),
+    true,
+    "state must remain committed — rollback must not override it",
+  );
+  assertEquals(tx.isRolledBack(), false);
+});
+
+Deno.test("step() throws if called after commit", async () => {
+  const tx = new TransactionScope();
+  await tx.commit();
+  await assertRejects(
+    () => tx.step("late-step", () => Promise.resolve()),
+    Error,
+    "called after committed",
+  );
+});
+
+Deno.test("step() throws if called after rollback", async () => {
+  const tx = new TransactionScope();
+  await tx.rollback(new Error("boom"));
+  await assertRejects(
+    () => tx.step("late-step", () => Promise.resolve()),
+    Error,
+    "called after rolledBack",
+  );
+});
+
+Deno.test("action failure does not invoke compensationFactory", async () => {
+  const tx = new TransactionScope();
+  let factoryInvocations = 0;
+
+  await assertRejects(
+    () =>
+      tx.step(
+        "label-add",
+        () => Promise.reject(new Error("action boom")),
+        () => {
+          factoryInvocations += 1;
+          return {
+            label: "should-not-exist",
+            idempotencyKey: "never",
+            run: () => Promise.resolve(),
+          };
+        },
+      ),
+    Error,
+    "action boom",
+  );
+
+  assertEquals(
+    factoryInvocations,
+    0,
+    "compensationFactory must only be called after action resolves",
+  );
+  assertEquals(
+    tx.pendingCount(),
+    0,
+    "stack must be empty after a failed action",
+  );
+});
+
+Deno.test("LIFO order is preserved for four sequential compensations", async () => {
+  const tx = new TransactionScope();
+  const executionLog: string[] = [];
+  const registrationOrder = ["step-A", "step-B", "step-C", "step-D"];
+  const expectedOrder = [...registrationOrder].reverse();
+
+  for (const label of registrationOrder) {
+    await tx.step(
+      `action-${label}`,
+      () => Promise.resolve(),
+      () => makeCompensation(label, executionLog),
+    );
+  }
+  assertEquals(
+    tx.pendingCount(),
+    registrationOrder.length,
+    "stack size must equal registration count",
+  );
+
+  const report = await tx.rollback(new Error("cause"));
+  assertEquals(
+    executionLog.length,
+    registrationOrder.length,
+    "non-vacuity: every compensation must run",
+  );
+  assertEquals(executionLog, expectedOrder);
+  assertEquals(report.attempted, registrationOrder.length);
+  assertEquals(report.succeeded, registrationOrder.length);
+  assertEquals(report.partial, false);
+});
+
+Deno.test("record() before any step also participates in LIFO rollback", async () => {
+  const tx = new TransactionScope();
+  const executionLog: string[] = [];
+
+  // Directly record a compensation (e.g. a precomputed snapshot restorer).
+  tx.record(makeCompensation("snapshot-restore", executionLog));
+  await tx.step(
+    "label-add",
+    () => Promise.resolve(),
+    () => makeCompensation("restore-labels-remove", executionLog),
+  );
+  assertEquals(tx.pendingCount(), 2);
+
+  const expectedOrder = ["restore-labels-remove", "snapshot-restore"];
+  const report = await tx.rollback(new Error("cause"));
+  assertEquals(
+    executionLog,
+    expectedOrder,
+    "record()-pushed compensation must roll back after later step()-pushed ones",
+  );
+  assertEquals(report.attempted, expectedOrder.length);
+  assertEquals(report.succeeded, expectedOrder.length);
+});
+
+Deno.test("logger throwing does not break rollback", async () => {
+  const brokenLogger: TransactionLogger = {
+    warn: () => Promise.reject(new Error("logger sink is down")),
+  };
+  const tx = new TransactionScope({ logger: brokenLogger });
+  const executionLog: string[] = [];
+  const compensationError = new Error("compensation boom");
+
+  await tx.step(
+    "label-add",
+    () => Promise.resolve(),
+    () =>
+      makeCompensation("restore-labels-remove", executionLog, {
+        throwOnRun: compensationError,
+      }),
+  );
+
+  // Must not throw despite both compensation AND logger failing.
+  const report = await tx.rollback(new Error("cause"));
+  assertEquals(report.attempted, 1);
+  assertEquals(report.succeeded, 0);
+  assertEquals(report.failed.length, 1);
+  assertEquals(report.failed[0].error, compensationError);
+  assertEquals(report.partial, true);
+});
+
+Deno.test("commit() is idempotent", async () => {
+  const tx = new TransactionScope();
+  await tx.step("label-add", () => Promise.resolve());
+  await tx.commit();
+  // Second commit must be a silent no-op.
+  await tx.commit();
+  assertEquals(tx.isCommitted(), true);
+  assertEquals(tx.isRolledBack(), false);
+});
+
+Deno.test("CompensationFailure preserves non-Error throws as Error instances", async () => {
+  const tx = new TransactionScope({ logger: newRecordingLogger() });
+  const executionLog: string[] = [];
+  const thrownValue = "string-shaped failure";
+
+  // Inject a compensation that rejects with a non-Error value.
+  tx.record({
+    label: "odd-compensation",
+    idempotencyKey: "key:odd",
+    run: () => {
+      executionLog.push("odd-compensation");
+      return Promise.reject(thrownValue);
+    },
+  });
+
+  const report = await tx.rollback(new Error("cause"));
+  assertEquals(executionLog, ["odd-compensation"]);
+  assertEquals(report.failed.length, 1);
+  assertEquals(
+    report.failed[0].error instanceof Error,
+    true,
+    "non-Error rejections must be normalized to Error before surfacing",
+  );
+  assertEquals(report.failed[0].error.message, thrownValue);
+});

--- a/agents/scripts/run-agent.ts
+++ b/agents/scripts/run-agent.ts
@@ -265,6 +265,29 @@ async function main(): Promise<void> {
       }
     }
 
+    // Label existence
+    if (result.labelExistenceResult) {
+      if (result.labelExistenceResult.valid) {
+        // deno-lint-ignore no-console
+        console.log("  \u2713 Labels \u2014 All declared labels exist on repo");
+      } else {
+        // deno-lint-ignore no-console
+        console.log("  \u2717 Labels \u2014 Missing labels on repository:");
+        for (const err of result.labelExistenceResult.errors) {
+          // deno-lint-ignore no-console
+          console.log(`    - ${err}`);
+        }
+        totalErrors += result.labelExistenceResult.errors.length;
+      }
+      if (result.labelExistenceResult.warnings.length > 0) {
+        for (const warn of result.labelExistenceResult.warnings) {
+          // deno-lint-ignore no-console
+          console.log(`  \u26A0 Labels \u2014 ${warn}`);
+        }
+        totalWarnings += result.labelExistenceResult.warnings.length;
+      }
+    }
+
     // Flow reachability
     if (result.flowResult) {
       if (result.flowResult.valid) {


### PR DESCRIPTION
## Summary

- Introduce `TransactionScope` (LIFO compensation registry) and rewrite the orchestrator phase-transition block as a T1..T7 saga. Eliminates the "label 宙ぶらり" gap where a successful label update followed by a failed `closeIssue` left the issue inconsistent.
- Add `reopenIssue` / `getRecentComments` to `GitHubClient` (interface + GhCliClient + FileGitHubClient + test stubs) for compensation and marker-based idempotency.
- Export `compensationMarker(issueNumber, cycleSeq)` as the single source of truth for marker identity; switch to a visible footer signature so operators can audit compensation comments without reading HTML comments.
- Strengthen `test-design` skill: Derivation ladder, Decision Framework Q4 (assertion-to-invariant alignment), three new anti-patterns (Prose derivation alibi / Assertion bloat / Delegation trust), and Workflow steps 10-11 (scope expansion on review, re-audit on delegation).
- Sync docs in the same PR: `12_orchestrator.md`, `09_contracts.md`, `04_step_flow_design.md`.

## Key design calls

- **T6 pre-register pattern**: `scope.record(...)` runs *before* `closeIssue` so the compensation comment is posted even when the action itself throws. A factory on `step()` would only fire after success.
- **cycleTracker.record moves to the success path**: previously fired before close, which would have advanced cycleSeq for a failed cycle and broken marker dedup.
- **Visible footer marker** (`<sub>🤖 climpt-compensation:issue-N:cycle-C</sub>`): prioritizes operator auditability; bot-authored comments are not edited so robustness is retained.

## Test plan

- [x] `deno task ci` — 7/7 stages pass (type check, test, lint, JSR, format)
- [x] `deno test agents/orchestrator/` — 321 tests pass (1644 across the full suite)
- [x] New `transaction-scope_test.ts` — 16 cases (LIFO order, post-commit no-op, compensation failure best-effort, non-Error normalization)
- [x] New self-heal integration test: T6 fails on run 1 → status blocked; run 2 reaches completed; compensation comment count stays at 1 across both runs
- [x] Existing "closeIssue failure is non-fatal" test rewritten to the new contract (fatal → blocked + compensation comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)