### PR TITLE
feat(orchestrator): declarative labels in workflow.json with idempotent sync

### DIFF
--- a/.agent/CLAUDE.md
+++ b/.agent/CLAUDE.md
@@ -61,8 +61,12 @@ Two-stage pipeline for GitHub Issues:
 
    Single-issue mode: append `--issue <N>` to target one issue.
 
-Labels required in repo: `kind:impl`, `kind:consider`,
-`order:1` .. `order:9`, `done`, `need clearance`.
+Repository labels (name, color, description) are the declarative source
+of truth in `.agent/workflow.json` under the `labels` section. The
+orchestrator reconciles them on every batch start, and the triager does
+the same via `deno task labels:sync` as its Step 1. Contributors who add
+or rename a workflow label MUST update `labels` in `workflow.json` —
+never the triager prompt (which now only invokes the syncer).
 
 ## Operating contexts
 

--- a/.agent/triager/prompts/steps/closure/triage/f_default.md
+++ b/.agent/triager/prompts/steps/closure/triage/f_default.md
@@ -50,54 +50,30 @@ jq -r "
 Save the output as `WORKFLOW_LABELS` (one per line) for reuse in Steps 1
 and 2.
 
-## Step 1 — Ensure every workflow label exists in the repo (idempotent)
+## Step 1 — Reconcile workflow labels with the repository (idempotent)
 
-Each workflow label needs to exist before any agent applies it. Create
-missing ones from a known color/description table. Labels not in the table
-get a neutral default.
+Label specs (name + color + description) are declared in the workflow
+JSON under the `labels` section — a single source of truth shared by the
+orchestrator and this agent. Invoke the TypeScript syncer to create
+missing labels and update any whose color/description drifted:
 
 ```bash
 bash -c '
 set -euo pipefail
-WORKFLOW="{uv-workflow}"
-
-WORKFLOW_LABELS=$(jq -r "
-  [ (.labelMapping // {} | keys[]),
-    (.prioritizer.labels // [])[] ]
-  | unique[]
-" "$WORKFLOW")
-
-EXISTING=$(gh label list --limit 200 --json name --jq ".[].name")
-
-# Color/description table for known labels (name|color|description)
-declare -A COLOR DESC
-lookup() {
-  case "$1" in
-    kind:impl)       echo "a2eeef|Implementation work (iterator)" ;;
-    kind:consider)   echo "bfd4f2|Consideration/response (considerer)" ;;
-    order:1)         echo "c2e0c6|Work order seq 1 (higher = sooner)" ;;
-    order:[2-9])     echo "c2e0c6|Work order seq ${1#order:}" ;;
-    done)            echo "0e8a16|Work completed (awaiting orchestrator close)" ;;
-    "need clearance") echo "d93f0b|Blocked — requires human clearance" ;;
-    *)               echo "cccccc|Workflow label" ;;
-  esac
-}
-
-while IFS= read -r name; do
-  [ -z "$name" ] && continue
-  if ! printf "%s\n" "$EXISTING" | grep -Fxq "$name"; then
-    spec=$(lookup "$name")
-    color="${spec%%|*}"
-    desc="${spec#*|}"
-    gh label create "$name" --color "$color" --description "$desc"
-  fi
-done <<< "$WORKFLOW_LABELS"
+deno task labels:sync --workflow "{uv-workflow}"
 '
 ```
 
-Do NOT recreate labels that already exist. Do NOT change colors or
-descriptions of existing labels. On failure, stop and report; do not
-proceed.
+The syncer is per-label try/catch: one label failing (e.g. the GitHub
+token lacks `repo` scope for that specific label) does not abort the
+rest of the run. It prints a summary of `created / updated / nochange /
+failed` counts and exits `1` if any label failed. If the exit code is
+`1`, inspect which label failed from the syncer's output and report it
+alongside the triage summary — do not attempt to mutate the repository
+via ad-hoc `gh label` commands from this prompt.
+
+Do NOT open a bash block that calls `gh label create` / `gh label edit`
+directly — the syncer is the only way labels should be touched.
 
 ## Step 2 — List open issues missing all workflow labels
 

--- a/.agent/workflow.json
+++ b/.agent/workflow.json
@@ -31,6 +31,64 @@
     "done": "done",
     "need clearance": "blocked"
   },
+  "labels": {
+    "kind:impl": {
+      "color": "a2eeef",
+      "description": "Implementation work (iterator)"
+    },
+    "kind:detail": {
+      "color": "fbca04",
+      "description": "Specification detailing (detailer)"
+    },
+    "kind:consider": {
+      "color": "bfd4f2",
+      "description": "Consideration/response (considerer)"
+    },
+    "done": {
+      "color": "0e8a16",
+      "description": "Work completed (awaiting orchestrator close)"
+    },
+    "need clearance": {
+      "color": "d93f0b",
+      "description": "Blocked — requires human clearance"
+    },
+    "order:1": {
+      "color": "c2e0c6",
+      "description": "Work order seq 1 (higher = sooner)"
+    },
+    "order:2": {
+      "color": "c2e0c6",
+      "description": "Work order seq 2"
+    },
+    "order:3": {
+      "color": "c2e0c6",
+      "description": "Work order seq 3"
+    },
+    "order:4": {
+      "color": "c2e0c6",
+      "description": "Work order seq 4"
+    },
+    "order:5": {
+      "color": "c2e0c6",
+      "description": "Work order seq 5"
+    },
+    "order:6": {
+      "color": "c2e0c6",
+      "description": "Work order seq 6"
+    },
+    "order:7": {
+      "color": "c2e0c6",
+      "description": "Work order seq 7"
+    },
+    "order:8": {
+      "color": "c2e0c6",
+      "description": "Work order seq 8"
+    },
+    "order:9": {
+      "color": "c2e0c6",
+      "description": "Work order seq 9"
+    }
+  },
   "agents": {
     "iterator": {
       "role": "transformer",

--- a/agents/config/label-existence-validator_test.ts
+++ b/agents/config/label-existence-validator_test.ts
@@ -61,6 +61,11 @@ function fakeClient(
     listIssues: unsupported("listIssues"),
     getIssueDetail: unsupported("getIssueDetail"),
     getRecentComments: unsupported("getRecentComments"),
+    // Phase 2 label-spec methods — not touched by the existence validator,
+    // but part of the GitHubClient surface.
+    listLabelsDetailed: unsupported("listLabelsDetailed"),
+    createLabel: unsupported("createLabel"),
+    updateLabel: unsupported("updateLabel"),
   } as GitHubClient;
 }
 

--- a/agents/orchestrator/batch-runner.ts
+++ b/agents/orchestrator/batch-runner.ts
@@ -24,6 +24,7 @@ import { Queue } from "./queue.ts";
 import { wfBatchPrioritizeMissingConfig } from "../shared/errors/config-errors.ts";
 import { OrchestratorLogger } from "./orchestrator-logger.ts";
 import { countdownDelay } from "./countdown.ts";
+import { summarizeSync, syncLabels } from "./label-sync.ts";
 
 /** Interface for single-issue workflow execution, used by BatchRunner. */
 export interface SingleIssueRunner {
@@ -113,6 +114,14 @@ export class BatchRunner {
     options: BatchOptions | undefined,
     log: OrchestratorLogger,
   ): Promise<BatchResult> {
+    // 0a. Preflight: reconcile repository labels against workflow.json#labels.
+    // Runs once per batch, before any dispatch. Per-label try/catch inside
+    // syncLabels ensures a single permission / transport error does not abort
+    // the whole batch — aggregate failures are logged and the batch continues.
+    // The actual use site (phase transition, gh issue edit) will surface a
+    // hard error later if a required label is still missing.
+    await this.#preflightLabelSync(log, options?.dryRun ?? false);
+
     const syncer = new IssueSyncer(this.#github, store);
 
     // 1. Sync issues from gh to local store
@@ -262,5 +271,73 @@ export class BatchRunner {
       totalIssues: issueNumbers.length,
       status: batchStatus,
     };
+  }
+
+  /**
+   * One-time label reconciliation before the batch dispatches anything.
+   *
+   * Failure policy: per-label errors are absorbed by syncLabels and
+   * surfaced as a summary + per-failure warn events. The batch then
+   * continues — the orchestrator's existing phase-transition logic
+   * raises a concrete error at the actual use site if a required
+   * label is truly missing, which is preferred over aborting at
+   * preflight (a partial sync is often still usable).
+   *
+   * Bailout: if `workflow.json#labels` is absent or empty, the
+   * preflight logs a single info event and returns without touching
+   * the repository. This keeps backwards compatibility for configs
+   * that have not migrated yet (though the loader already rejects
+   * such configs for workflows that reference any label — see
+   * WF-LABEL-003).
+   */
+  async #preflightLabelSync(
+    log: OrchestratorLogger,
+    dryRun: boolean,
+  ): Promise<void> {
+    const specs = this.#config.labels;
+    if (!specs || Object.keys(specs).length === 0) {
+      await log.info(
+        "Label sync preflight skipped: no labels[] declared in workflow.json",
+        { event: "label_sync_skipped" },
+      );
+      return;
+    }
+
+    await log.info(
+      `Label sync preflight: ${Object.keys(specs).length} declared specs${
+        dryRun ? " (dry-run)" : ""
+      }`,
+      { event: "label_sync_start", declaredCount: Object.keys(specs).length },
+    );
+
+    let results;
+    try {
+      results = await syncLabels(this.#github, specs, { dryRun });
+    } catch (error) {
+      // listLabelsDetailed failed — no baseline → no safe reconciliation.
+      // Log and continue; downstream will surface concrete failures.
+      const msg = error instanceof Error ? error.message : String(error);
+      await log.error(
+        `Label sync preflight failed to read label state: ${msg}`,
+        { event: "label_sync_baseline_failed", error: msg },
+      );
+      return;
+    }
+
+    await log.info(summarizeSync(results), {
+      event: "label_sync_summary",
+      dryRun,
+      results,
+    });
+
+    // Surface failures individually so they are searchable by label name.
+    for (const r of results) {
+      if (r.action === "failed") {
+        await log.error(
+          `Label sync failed for "${r.name}": ${r.error ?? "unknown error"}`,
+          { event: "label_sync_failed", label: r.name, error: r.error },
+        );
+      }
+    }
   }
 }

--- a/agents/orchestrator/file-github-client.ts
+++ b/agents/orchestrator/file-github-client.ts
@@ -12,6 +12,7 @@ import type {
   IssueCriteria,
   IssueDetail,
   IssueListItem,
+  LabelDetail,
 } from "./github-client.ts";
 import type { IssueStore } from "./issue-store.ts";
 
@@ -131,16 +132,122 @@ export class FileGitHubClient implements GitHubClient {
     try {
       const text = await Deno.readTextFile(path);
       const parsed = JSON.parse(text);
-      if (!Array.isArray(parsed)) {
-        throw new Error(
-          `labels.json must contain a JSON array of strings, got ${typeof parsed}`,
-        );
+      if (Array.isArray(parsed)) {
+        // Legacy flat format: array of strings.
+        return parsed.filter((x): x is string => typeof x === "string");
       }
-      return parsed.filter((x): x is string => typeof x === "string");
+      if (parsed && typeof parsed === "object") {
+        // Detailed format: object keyed by name → {color, description}.
+        return Object.keys(parsed);
+      }
+      throw new Error(
+        `labels.json must be a JSON array or object, got ${typeof parsed}`,
+      );
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) return [];
       throw error;
     }
+  }
+
+  async listLabelsDetailed(): Promise<LabelDetail[]> {
+    const path = `${this.#store.storePath}/labels.json`;
+    try {
+      const text = await Deno.readTextFile(path);
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) {
+        // Legacy flat format: array of strings has no color/description.
+        return parsed
+          .filter((x): x is string => typeof x === "string")
+          .map((name) => ({ name, color: "", description: "" }));
+      }
+      if (parsed && typeof parsed === "object") {
+        const result: LabelDetail[] = [];
+        for (const [name, raw] of Object.entries(parsed)) {
+          const spec = raw as { color?: string; description?: string };
+          result.push({
+            name,
+            color: (spec.color ?? "").replace(/^#/, "").toLowerCase(),
+            description: spec.description ?? "",
+          });
+        }
+        return result;
+      }
+      throw new Error(
+        `labels.json must be a JSON array or object, got ${typeof parsed}`,
+      );
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return [];
+      throw error;
+    }
+  }
+
+  async createLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<void> {
+    const existing = await this.#readLabelMap();
+    if (Object.prototype.hasOwnProperty.call(existing, name)) {
+      throw new Error(`Label "${name}" already exists`);
+    }
+    existing[name] = {
+      color: color.toLowerCase(),
+      description,
+    };
+    await this.#writeLabelMap(existing);
+  }
+
+  async updateLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<void> {
+    const existing = await this.#readLabelMap();
+    if (!Object.prototype.hasOwnProperty.call(existing, name)) {
+      throw new Error(`Label "${name}" does not exist`);
+    }
+    existing[name] = {
+      color: color.toLowerCase(),
+      description,
+    };
+    await this.#writeLabelMap(existing);
+  }
+
+  async #readLabelMap(): Promise<
+    Record<string, { color: string; description: string }>
+  > {
+    const path = `${this.#store.storePath}/labels.json`;
+    try {
+      const text = await Deno.readTextFile(path);
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) {
+        // Upgrade legacy flat format in-memory; writer will persist detailed.
+        const map: Record<string, { color: string; description: string }> = {};
+        for (const name of parsed) {
+          if (typeof name === "string") {
+            map[name] = { color: "", description: "" };
+          }
+        }
+        return map;
+      }
+      if (parsed && typeof parsed === "object") {
+        return parsed as Record<string, { color: string; description: string }>;
+      }
+      throw new Error(
+        `labels.json must be a JSON array or object, got ${typeof parsed}`,
+      );
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return {};
+      throw error;
+    }
+  }
+
+  async #writeLabelMap(
+    map: Record<string, { color: string; description: string }>,
+  ): Promise<void> {
+    const path = `${this.#store.storePath}/labels.json`;
+    await Deno.mkdir(this.#store.storePath, { recursive: true });
+    await Deno.writeTextFile(path, JSON.stringify(map, null, 2));
   }
 
   async getIssueDetail(issueNumber: number): Promise<IssueDetail> {

--- a/agents/orchestrator/github-client.ts
+++ b/agents/orchestrator/github-client.ts
@@ -30,6 +30,14 @@ export interface IssueDetail {
   comments: { id: string; body: string }[];
 }
 
+/** Detailed label record returned by listLabelsDetailed. */
+export interface LabelDetail {
+  name: string;
+  /** 6-char hex color without leading '#' */
+  color: string;
+  description: string;
+}
+
 /** Abstract interface for GitHub issue operations. */
 export interface GitHubClient {
   getIssueLabels(issueNumber: number): Promise<string[]>;
@@ -49,6 +57,26 @@ export interface GitHubClient {
     limit: number,
   ): Promise<{ body: string; createdAt: string }[]>;
   listLabels(): Promise<string[]>;
+
+  /**
+   * Label lifecycle operations used by the pre-dispatch label-sync
+   * preflight. Implementations must be idempotent at the transport
+   * layer: createLabel on an existing name, or updateLabel to the
+   * current state, should raise a distinguishable error rather than
+   * silently mutating unrelated labels. Sync callers wrap these with
+   * try/catch and emit per-label status records.
+   */
+  listLabelsDetailed(): Promise<LabelDetail[]>;
+  createLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<void>;
+  updateLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<void>;
 }
 
 /** Concrete implementation using `gh` CLI via Deno.Command. */
@@ -376,5 +404,99 @@ export class GhCliClient implements GitHubClient {
 
     const raw = JSON.parse(stdout) as { name: string }[];
     return raw.map((l) => l.name);
+  }
+
+  async listLabelsDetailed(): Promise<LabelDetail[]> {
+    const cmd = new Deno.Command("gh", {
+      args: [
+        "label",
+        "list",
+        "--json",
+        "name,color,description",
+        "--limit",
+        "1000",
+      ],
+      cwd: this.#cwd,
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await cmd.output();
+
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      throw new Error(`Failed to list labels: ${stderr}`);
+    }
+
+    const stdout = new TextDecoder().decode(output.stdout).trim();
+    if (stdout === "") return [];
+
+    const raw = JSON.parse(stdout) as {
+      name: string;
+      color: string;
+      description?: string;
+    }[];
+    return raw.map((l) => ({
+      name: l.name,
+      // gh returns color without leading '#'; normalize for safety.
+      color: (l.color ?? "").replace(/^#/, "").toLowerCase(),
+      description: l.description ?? "",
+    }));
+  }
+
+  async createLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<void> {
+    const cmd = new Deno.Command("gh", {
+      args: [
+        "label",
+        "create",
+        name,
+        "--color",
+        color,
+        "--description",
+        description,
+      ],
+      cwd: this.#cwd,
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await cmd.output();
+
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      throw new Error(`Failed to create label "${name}": ${stderr}`);
+    }
+  }
+
+  async updateLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<void> {
+    const cmd = new Deno.Command("gh", {
+      args: [
+        "label",
+        "edit",
+        name,
+        "--color",
+        color,
+        "--description",
+        description,
+      ],
+      cwd: this.#cwd,
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await cmd.output();
+
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      throw new Error(`Failed to update label "${name}": ${stderr}`);
+    }
   }
 }

--- a/agents/orchestrator/integration_handoff_test.ts
+++ b/agents/orchestrator/integration_handoff_test.ts
@@ -136,6 +136,28 @@ class StubGitHubClient implements GitHubClient {
   listLabels(): Promise<string[]> {
     return Promise.resolve([]);
   }
+
+  listLabelsDetailed(): Promise<
+    { name: string; color: string; description: string }[]
+  > {
+    return Promise.resolve([]);
+  }
+
+  createLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  updateLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 /** Stub dispatcher that records calls and returns a prepared outcome. */

--- a/agents/orchestrator/integration_test.ts
+++ b/agents/orchestrator/integration_test.ts
@@ -203,6 +203,28 @@ class StubGitHubClient implements GitHubClient {
   listLabels(): Promise<string[]> {
     return Promise.resolve([]);
   }
+
+  listLabelsDetailed(): Promise<
+    { name: string; color: string; description: string }[]
+  > {
+    return Promise.resolve([]);
+  }
+
+  createLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  updateLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 // =============================================================

--- a/agents/orchestrator/issue-syncer_test.ts
+++ b/agents/orchestrator/issue-syncer_test.ts
@@ -86,6 +86,28 @@ class StubGitHubClient implements GitHubClient {
   listLabels(): Promise<string[]> {
     return Promise.resolve([]);
   }
+
+  listLabelsDetailed(): Promise<
+    { name: string; color: string; description: string }[]
+  > {
+    return Promise.resolve([]);
+  }
+
+  createLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  updateLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 function makeDetail(num: number): IssueDetail {

--- a/agents/orchestrator/label-sync.ts
+++ b/agents/orchestrator/label-sync.ts
@@ -1,0 +1,145 @@
+/**
+ * Label Sync - Idempotent pre-dispatch label reconciliation.
+ *
+ * Reads declarative `labels` specs from workflow.json and reconciles
+ * them against the GitHub repository label set. Per-label try/catch
+ * isolates failures so a single permission / transport error does not
+ * abort the rest of the batch. Caller logs aggregate results and
+ * decides whether to continue — this module never throws for
+ * individual label failures.
+ *
+ * Design rationale: agents/docs/design/... (Phase 2 of the
+ * label-bootstrap-failure remediation). The previous bash-based
+ * bootstrap (triager prompt, Step 1) was fragile under `set -e` and
+ * hid color/description metadata inside a prompt file. By moving
+ * specs to workflow.json and the sync logic to TypeScript, we get
+ * per-label error isolation and a single source of truth.
+ */
+
+import type { GitHubClient, LabelDetail } from "./github-client.ts";
+import type { LabelSpec } from "./workflow-types.ts";
+
+/** Classification of per-label sync outcomes. */
+export type SyncAction = "created" | "updated" | "nochange" | "failed";
+
+/** Result of syncing a single label. */
+export interface SyncResult {
+  name: string;
+  action: SyncAction;
+  /** Present only when action === "failed". */
+  error?: string;
+}
+
+/** Options for the top-level sync entry point. */
+export interface SyncOptions {
+  /**
+   * When true, compute what would change but skip create/update
+   * gh calls. Returns `created`/`updated`/`nochange` as if the
+   * operation had succeeded so callers can still log a summary.
+   */
+  dryRun?: boolean;
+}
+
+/**
+ * Compare current label state to declared specs and return the
+ * needed action. Pure function — no I/O.
+ *
+ * Used by syncLabels internally and exported for unit testing /
+ * reuse in dry-run reporting.
+ */
+export function decideLabelAction(
+  spec: LabelSpec,
+  current: LabelDetail | undefined,
+): Exclude<SyncAction, "failed"> {
+  if (!current) return "created";
+  const currentColor = current.color.toLowerCase();
+  const specColor = spec.color.toLowerCase();
+  if (
+    currentColor === specColor &&
+    current.description === spec.description
+  ) {
+    return "nochange";
+  }
+  return "updated";
+}
+
+/**
+ * Sync label specs against the repository via the provided GitHubClient.
+ *
+ * Behavior:
+ * - Calls `listLabelsDetailed()` once to snapshot the current state.
+ *   Failure here throws (caller cannot proceed without a baseline).
+ * - For each spec, dispatches to create/update/nochange per the
+ *   decision function above. Per-label errors are captured into
+ *   `SyncResult.error` and do NOT abort the batch.
+ * - Order of returned results matches declaration order in `specs`
+ *   (stable, deterministic).
+ *
+ * @param github    GitHubClient implementation (gh CLI or file-based)
+ * @param specs     Label name → spec mapping from workflow.json#labels
+ * @param options   dryRun skips create/update calls but still classifies
+ */
+export async function syncLabels(
+  github: GitHubClient,
+  specs: Readonly<Record<string, LabelSpec>>,
+  options: SyncOptions = {},
+): Promise<SyncResult[]> {
+  const dryRun = options.dryRun ?? false;
+
+  const current = await github.listLabelsDetailed();
+  const currentByName = new Map<string, LabelDetail>();
+  for (const label of current) {
+    currentByName.set(label.name, label);
+  }
+
+  const results: SyncResult[] = [];
+  for (const [name, spec] of Object.entries(specs)) {
+    const action = decideLabelAction(spec, currentByName.get(name));
+
+    if (action === "nochange") {
+      results.push({ name, action });
+      continue;
+    }
+
+    if (dryRun) {
+      results.push({ name, action });
+      continue;
+    }
+
+    try {
+      if (action === "created") {
+        await github.createLabel(name, spec.color, spec.description);
+      } else {
+        await github.updateLabel(name, spec.color, spec.description);
+      }
+      results.push({ name, action });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      results.push({ name, action: "failed", error: msg });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Human-readable summary line from sync results. Counts by action —
+ * callers typically log this alongside the full `SyncResult[]` for
+ * post-mortem analysis.
+ */
+export function summarizeSync(results: readonly SyncResult[]): string {
+  const counts: Record<SyncAction, number> = {
+    created: 0,
+    updated: 0,
+    nochange: 0,
+    failed: 0,
+  };
+  for (const r of results) {
+    counts[r.action]++;
+  }
+  return (
+    `labels: ${results.length} total ` +
+    `(created=${counts.created}, updated=${counts.updated}, ` +
+    `nochange=${counts.nochange}, failed=${counts.failed})`
+  );
+}

--- a/agents/orchestrator/label-sync_test.ts
+++ b/agents/orchestrator/label-sync_test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for agents/orchestrator/label-sync.ts
+ *
+ * Covers decideLabelAction (pure decision), syncLabels (create /
+ * update / nochange / failed), dryRun behaviour, and summarizeSync.
+ *
+ * Design: a stub GitHubClient implements only the subset of methods
+ * label-sync touches (`listLabelsDetailed`, `createLabel`,
+ * `updateLabel`). Every other method throws to make leaks surface
+ * loudly.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  decideLabelAction,
+  summarizeSync,
+  syncLabels,
+  type SyncResult,
+} from "./label-sync.ts";
+import type {
+  GitHubClient,
+  IssueCriteria,
+  IssueDetail,
+  IssueListItem,
+  LabelDetail,
+} from "./github-client.ts";
+import type { LabelSpec } from "./workflow-types.ts";
+
+// =============================================================================
+// Stub GitHubClient
+// =============================================================================
+
+interface StubOptions {
+  initial: LabelDetail[];
+  createFailures?: Set<string>;
+  updateFailures?: Set<string>;
+  listFails?: string;
+}
+
+function makeStub(options: StubOptions): {
+  github: GitHubClient;
+  creates: string[];
+  updates: string[];
+} {
+  const state = new Map<string, LabelDetail>();
+  for (const l of options.initial) {
+    state.set(l.name, { ...l });
+  }
+  const creates: string[] = [];
+  const updates: string[] = [];
+
+  const github: GitHubClient = {
+    async listLabelsDetailed(): Promise<LabelDetail[]> {
+      if (options.listFails !== undefined) {
+        throw new Error(options.listFails);
+      }
+      return await Promise.resolve([...state.values()]);
+    },
+    createLabel(name, color, description): Promise<void> {
+      if (options.createFailures?.has(name)) {
+        return Promise.reject(new Error(`create refused for ${name}`));
+      }
+      state.set(name, { name, color, description });
+      creates.push(name);
+      return Promise.resolve();
+    },
+    updateLabel(name, color, description): Promise<void> {
+      if (options.updateFailures?.has(name)) {
+        return Promise.reject(new Error(`update refused for ${name}`));
+      }
+      state.set(name, { name, color, description });
+      updates.push(name);
+      return Promise.resolve();
+    },
+    // Unused methods — throw on any accidental call.
+    getIssueLabels(): Promise<string[]> {
+      throw new Error("unexpected: getIssueLabels");
+    },
+    updateIssueLabels(): Promise<void> {
+      throw new Error("unexpected: updateIssueLabels");
+    },
+    addIssueComment(): Promise<void> {
+      throw new Error("unexpected: addIssueComment");
+    },
+    createIssue(): Promise<number> {
+      throw new Error("unexpected: createIssue");
+    },
+    closeIssue(): Promise<void> {
+      throw new Error("unexpected: closeIssue");
+    },
+    reopenIssue(): Promise<void> {
+      throw new Error("unexpected: reopenIssue");
+    },
+    listIssues(_: IssueCriteria): Promise<IssueListItem[]> {
+      throw new Error("unexpected: listIssues");
+    },
+    getIssueDetail(): Promise<IssueDetail> {
+      throw new Error("unexpected: getIssueDetail");
+    },
+    getRecentComments(): Promise<{ body: string; createdAt: string }[]> {
+      throw new Error("unexpected: getRecentComments");
+    },
+    listLabels(): Promise<string[]> {
+      throw new Error("unexpected: listLabels");
+    },
+  };
+
+  return { github, creates, updates };
+}
+
+// =============================================================================
+// decideLabelAction
+// =============================================================================
+
+Deno.test("decideLabelAction: missing -> created", () => {
+  const spec: LabelSpec = { color: "a2eeef", description: "d" };
+  assertEquals(decideLabelAction(spec, undefined), "created");
+});
+
+Deno.test("decideLabelAction: exact match -> nochange", () => {
+  const spec: LabelSpec = { color: "a2eeef", description: "d" };
+  assertEquals(
+    decideLabelAction(spec, { name: "x", color: "a2eeef", description: "d" }),
+    "nochange",
+  );
+});
+
+Deno.test("decideLabelAction: color differs -> updated", () => {
+  const spec: LabelSpec = { color: "a2eeef", description: "d" };
+  assertEquals(
+    decideLabelAction(spec, { name: "x", color: "ffffff", description: "d" }),
+    "updated",
+  );
+});
+
+Deno.test("decideLabelAction: description differs -> updated", () => {
+  const spec: LabelSpec = { color: "a2eeef", description: "new" };
+  assertEquals(
+    decideLabelAction(spec, { name: "x", color: "a2eeef", description: "old" }),
+    "updated",
+  );
+});
+
+Deno.test("decideLabelAction: color case-insensitive match -> nochange", () => {
+  const spec: LabelSpec = { color: "A2EEEF", description: "d" };
+  assertEquals(
+    decideLabelAction(spec, { name: "x", color: "a2eeef", description: "d" }),
+    "nochange",
+  );
+});
+
+// =============================================================================
+// syncLabels: per-label paths
+// =============================================================================
+
+Deno.test("syncLabels: creates missing labels", async () => {
+  const { github, creates, updates } = makeStub({ initial: [] });
+  const results = await syncLabels(github, {
+    "kind:impl": { color: "a2eeef", description: "impl" },
+  });
+  assertEquals(results, [{ name: "kind:impl", action: "created" }]);
+  assertEquals(creates, ["kind:impl"]);
+  assertEquals(updates, []);
+});
+
+Deno.test("syncLabels: updates labels whose color or description drifted", async () => {
+  const { github, creates, updates } = makeStub({
+    initial: [{ name: "kind:impl", color: "ffffff", description: "old" }],
+  });
+  const results = await syncLabels(github, {
+    "kind:impl": { color: "a2eeef", description: "impl" },
+  });
+  assertEquals(results, [{ name: "kind:impl", action: "updated" }]);
+  assertEquals(creates, []);
+  assertEquals(updates, ["kind:impl"]);
+});
+
+Deno.test("syncLabels: nochange when spec matches exactly", async () => {
+  const { github, creates, updates } = makeStub({
+    initial: [{ name: "kind:impl", color: "a2eeef", description: "impl" }],
+  });
+  const results = await syncLabels(github, {
+    "kind:impl": { color: "a2eeef", description: "impl" },
+  });
+  assertEquals(results, [{ name: "kind:impl", action: "nochange" }]);
+  assertEquals(creates, []);
+  assertEquals(updates, []);
+});
+
+Deno.test("syncLabels: failed create is isolated, other labels continue", async () => {
+  const { github, creates, updates } = makeStub({
+    initial: [],
+    createFailures: new Set(["kind:impl"]),
+  });
+  const results = await syncLabels(github, {
+    "kind:impl": { color: "a2eeef", description: "impl" },
+    "done": { color: "0e8a16", description: "done" },
+  });
+  assertEquals(results.length, 2);
+  assertEquals(results[0].name, "kind:impl");
+  assertEquals(results[0].action, "failed");
+  assertStringIncludes(results[0].error ?? "", "create refused");
+  assertEquals(results[1], { name: "done", action: "created" });
+  // "done" still got created despite "kind:impl" failing.
+  assertEquals(creates, ["done"]);
+  assertEquals(updates, []);
+});
+
+Deno.test("syncLabels: failed update is isolated", async () => {
+  const { github } = makeStub({
+    initial: [{ name: "kind:impl", color: "ffffff", description: "old" }],
+    updateFailures: new Set(["kind:impl"]),
+  });
+  const results = await syncLabels(github, {
+    "kind:impl": { color: "a2eeef", description: "impl" },
+  });
+  assertEquals(results.length, 1);
+  assertEquals(results[0].action, "failed");
+  assertStringIncludes(results[0].error ?? "", "update refused");
+});
+
+Deno.test("syncLabels: preserves declaration order in results", async () => {
+  const { github } = makeStub({ initial: [] });
+  const results = await syncLabels(github, {
+    "zeta": { color: "a2eeef", description: "z" },
+    "alpha": { color: "a2eeef", description: "a" },
+    "middle": { color: "a2eeef", description: "m" },
+  });
+  assertEquals(
+    results.map((r) => r.name),
+    ["zeta", "alpha", "middle"],
+    "Results must follow insertion order, not sorted — tests depend on predictable output.",
+  );
+});
+
+// =============================================================================
+// syncLabels: dryRun
+// =============================================================================
+
+Deno.test("syncLabels: dryRun skips create and update calls", async () => {
+  const { github, creates, updates } = makeStub({
+    initial: [{ name: "stale", color: "ffffff", description: "old" }],
+  });
+  const results = await syncLabels(
+    github,
+    {
+      "missing": { color: "a2eeef", description: "m" },
+      "stale": { color: "a2eeef", description: "new" },
+      "ok": { color: "a2eeef", description: "o" },
+    },
+    { dryRun: true },
+  );
+
+  assertEquals(results.length, 3);
+  assertEquals(
+    results.map((r) => r.action),
+    ["created", "updated", "created"],
+    "dryRun must still classify the intended action without actually applying it.",
+  );
+  // No side effects.
+  assertEquals(creates, []);
+  assertEquals(updates, []);
+});
+
+// =============================================================================
+// syncLabels: baseline read failure propagates
+// =============================================================================
+
+Deno.test("syncLabels: listLabelsDetailed failure propagates to caller", async () => {
+  const { github } = makeStub({
+    initial: [],
+    listFails: "token missing repo scope",
+  });
+  let caught: unknown;
+  try {
+    await syncLabels(github, {
+      "any": { color: "a2eeef", description: "a" },
+    });
+  } catch (e) {
+    caught = e;
+  }
+  if (!(caught instanceof Error)) {
+    throw new Error("Expected Error, got: " + String(caught));
+  }
+  assertStringIncludes(caught.message, "token missing repo scope");
+});
+
+// =============================================================================
+// summarizeSync
+// =============================================================================
+
+Deno.test("summarizeSync: reports all four action counts", () => {
+  const results: SyncResult[] = [
+    { name: "a", action: "created" },
+    { name: "b", action: "created" },
+    { name: "c", action: "updated" },
+    { name: "d", action: "nochange" },
+    { name: "e", action: "failed", error: "boom" },
+  ];
+  const summary = summarizeSync(results);
+  assertStringIncludes(summary, "5 total");
+  assertStringIncludes(summary, "created=2");
+  assertStringIncludes(summary, "updated=1");
+  assertStringIncludes(summary, "nochange=1");
+  assertStringIncludes(summary, "failed=1");
+});
+
+Deno.test("summarizeSync: all-zero when empty", () => {
+  const summary = summarizeSync([]);
+  assertStringIncludes(summary, "0 total");
+  assertStringIncludes(summary, "created=0");
+});

--- a/agents/orchestrator/mod.ts
+++ b/agents/orchestrator/mod.ts
@@ -16,6 +16,7 @@ export type {
   IssueCriteria,
   IssueStoreConfig,
   IssueWorkflowState,
+  LabelSpec,
   OrchestratorOptions,
   OrchestratorResult,
   PhaseDefinition,
@@ -55,9 +56,14 @@ export type {
   GitHubClient,
   IssueDetail,
   IssueListItem,
+  LabelDetail,
 } from "./github-client.ts";
 export { GhCliClient } from "./github-client.ts";
 export { FileGitHubClient } from "./file-github-client.ts";
+
+// Label sync
+export type { SyncAction, SyncOptions, SyncResult } from "./label-sync.ts";
+export { decideLabelAction, summarizeSync, syncLabels } from "./label-sync.ts";
 
 // Dispatcher
 export type {

--- a/agents/orchestrator/orchestrator.ts
+++ b/agents/orchestrator/orchestrator.ts
@@ -32,6 +32,7 @@ import { OrchestratorLogger } from "./orchestrator-logger.ts";
 import { BatchRunner } from "./batch-runner.ts";
 import { countdownDelay } from "./countdown.ts";
 import { TransactionScope } from "./transaction-scope.ts";
+import { summarizeSync, syncLabels } from "./label-sync.ts";
 
 export type { OrchestratorOptions, OrchestratorResult };
 
@@ -84,6 +85,14 @@ export class Orchestrator {
       await OrchestratorLogger.create(this.#cwd, {
         verbose: options?.verbose,
       });
+
+    // Preflight label sync — only when this orchestrator owns the logger,
+    // i.e. single-issue mode where BatchRunner has NOT already synced.
+    // The BatchRunner passes its own logger in, so we use that as the
+    // "running inside a batch" signal to avoid double-syncing.
+    if (ownsLogger) {
+      await this.#preflightLabelSync(log, options?.dryRun ?? false);
+    }
 
     // Acquire per-issue lock when store is available to prevent
     // concurrent invocations on the same issue.
@@ -877,5 +886,60 @@ export class Orchestrator {
       this.#cwd,
     );
     return runner.run(criteria, options);
+  }
+
+  /**
+   * Single-issue preflight sync. Mirrors BatchRunner.#preflightLabelSync
+   * but runs only when no batch logger was passed in (i.e. the user
+   * invoked `--issue` directly). Kept as an instance method so the
+   * orchestrator can reconcile labels without callers reaching into
+   * BatchRunner internals.
+   */
+  async #preflightLabelSync(
+    log: OrchestratorLogger,
+    dryRun: boolean,
+  ): Promise<void> {
+    const specs = this.#config.labels;
+    if (!specs || Object.keys(specs).length === 0) {
+      await log.info(
+        "Label sync preflight skipped: no labels[] declared in workflow.json",
+        { event: "label_sync_skipped" },
+      );
+      return;
+    }
+
+    await log.info(
+      `Label sync preflight: ${Object.keys(specs).length} declared specs${
+        dryRun ? " (dry-run)" : ""
+      }`,
+      { event: "label_sync_start", declaredCount: Object.keys(specs).length },
+    );
+
+    let results;
+    try {
+      results = await syncLabels(this.#github, specs, { dryRun });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      await log.error(
+        `Label sync preflight failed to read label state: ${msg}`,
+        { event: "label_sync_baseline_failed", error: msg },
+      );
+      return;
+    }
+
+    await log.info(summarizeSync(results), {
+      event: "label_sync_summary",
+      dryRun,
+      results,
+    });
+
+    for (const r of results) {
+      if (r.action === "failed") {
+        await log.error(
+          `Label sync failed for "${r.name}": ${r.error ?? "unknown error"}`,
+          { event: "label_sync_failed", label: r.name, error: r.error },
+        );
+      }
+    }
   }
 }

--- a/agents/orchestrator/orchestrator_test.ts
+++ b/agents/orchestrator/orchestrator_test.ts
@@ -199,6 +199,32 @@ class StubGitHubClient implements GitHubClient {
   listLabels(): Promise<string[]> {
     return Promise.resolve([]);
   }
+
+  // Label spec methods (Phase 2 label preflight): default to inert stubs.
+  // Individual tests that care about preflight inspect LabelPreflight via
+  // a dedicated fixture; the default path returns an empty baseline and
+  // records nothing so pre-existing cycle/transition tests remain green.
+  listLabelsDetailed(): Promise<
+    { name: string; color: string; description: string }[]
+  > {
+    return Promise.resolve([]);
+  }
+
+  createLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  updateLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 // --- Tests ---
@@ -1017,6 +1043,31 @@ class BatchStubGitHubClient implements GitHubClient {
 
   listLabels(): Promise<string[]> {
     return Promise.resolve([]);
+  }
+
+  // Label spec methods (Phase 2 label preflight). BatchRunner calls
+  // listLabelsDetailed() once per batch; we return an empty baseline so the
+  // preflight becomes a no-op (nothing to create, nothing to update).
+  listLabelsDetailed(): Promise<
+    { name: string; color: string; description: string }[]
+  > {
+    return Promise.resolve([]);
+  }
+
+  createLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  updateLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/agents/orchestrator/outbox-processor_test.ts
+++ b/agents/orchestrator/outbox-processor_test.ts
@@ -108,6 +108,28 @@ class StubGitHubClient implements GitHubClient {
   async listLabels(): Promise<string[]> {
     return await Promise.resolve([]);
   }
+
+  async listLabelsDetailed(): Promise<
+    { name: string; color: string; description: string }[]
+  > {
+    return await Promise.resolve([]);
+  }
+
+  async createLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    await Promise.resolve();
+  }
+
+  async updateLabel(
+    _name: string,
+    _color: string,
+    _description: string,
+  ): Promise<void> {
+    await Promise.resolve();
+  }
 }
 
 /** Create a temp IssueStore with outbox directory ready. */

--- a/agents/orchestrator/preflight-label-sync_test.ts
+++ b/agents/orchestrator/preflight-label-sync_test.ts
@@ -1,0 +1,396 @@
+/**
+ * Preflight label-sync wiring tests.
+ *
+ * Contract under test (Phase 2): before any issue processing, both
+ * BatchRunner and Orchestrator (single-issue mode) must reconcile the
+ * repository's label set against `workflow.json#labels` exactly once,
+ * using the same `syncLabels` routine covered in `label-sync_test.ts`.
+ *
+ * Why it lives in its own file: the stubs in `orchestrator_test.ts` are
+ * locked down to specific label sequences that would short-circuit the
+ * preflight. Here we use a recording `GitHubClient` that tracks only the
+ * three label-spec methods (`listLabelsDetailed`, `createLabel`,
+ * `updateLabel`) while routing the rest to inert no-ops. This lets each
+ * test assert "preflight ran with exactly these specs" without fighting
+ * the issue-dispatch machinery.
+ *
+ * Non-goals: we do NOT assert on per-label colour format here (that is
+ * the loader's job — see `workflow-loader_test.ts`), and we do NOT assert
+ * on transition correctness (covered in `orchestrator_test.ts`).
+ */
+
+import { assertEquals } from "@std/assert";
+import type {
+  GitHubClient,
+  IssueCriteria,
+  IssueDetail,
+  IssueListItem,
+  LabelDetail,
+} from "./github-client.ts";
+import { StubDispatcher } from "./dispatcher.ts";
+import { Orchestrator } from "./orchestrator.ts";
+import { BatchRunner } from "./batch-runner.ts";
+import type { WorkflowConfig } from "./workflow-types.ts";
+
+// =============================================================================
+// Recording GitHub client — only label-spec methods are instrumented
+// =============================================================================
+
+interface LabelCall {
+  op: "list" | "create" | "update";
+  name?: string;
+  color?: string;
+  description?: string;
+}
+
+/**
+ * Recording GitHubClient that captures label-spec calls but stays inert
+ * for issue I/O. Exposes `.labelCalls` for assertions.
+ *
+ * Behaviour:
+ * - `listLabelsDetailed` returns whatever baseline the test provided.
+ *   Records a "list" call each invocation so tests can assert preflight
+ *   ran (or was invoked exactly N times across a batch + single-issue
+ *   sequence).
+ * - `createLabel` / `updateLabel` record the call and succeed silently.
+ * - All other methods return empty / no-op values so the outer
+ *   orchestrator flow makes no progress past sync (which is intentional
+ *   — we only care about preflight here).
+ */
+class RecordingGithubClient implements GitHubClient {
+  #baseline: LabelDetail[];
+  readonly labelCalls: LabelCall[] = [];
+
+  constructor(baseline: LabelDetail[] = []) {
+    this.#baseline = baseline;
+  }
+
+  listLabelsDetailed(): Promise<LabelDetail[]> {
+    this.labelCalls.push({ op: "list" });
+    return Promise.resolve(this.#baseline.map((l) => ({ ...l })));
+  }
+
+  createLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<void> {
+    this.labelCalls.push({ op: "create", name, color, description });
+    return Promise.resolve();
+  }
+
+  updateLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<void> {
+    this.labelCalls.push({ op: "update", name, color, description });
+    return Promise.resolve();
+  }
+
+  // --- Inert issue I/O ---
+  getIssueLabels(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+  updateIssueLabels(): Promise<void> {
+    return Promise.resolve();
+  }
+  addIssueComment(): Promise<void> {
+    return Promise.resolve();
+  }
+  createIssue(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  closeIssue(): Promise<void> {
+    return Promise.resolve();
+  }
+  reopenIssue(): Promise<void> {
+    return Promise.resolve();
+  }
+  getRecentComments(): Promise<{ body: string; createdAt: string }[]> {
+    return Promise.resolve([]);
+  }
+  listIssues(_: IssueCriteria): Promise<IssueListItem[]> {
+    // Return empty so the batch completes after preflight with no dispatch.
+    return Promise.resolve([]);
+  }
+  getIssueDetail(): Promise<IssueDetail> {
+    return Promise.resolve({
+      number: 0,
+      title: "",
+      body: "",
+      labels: [],
+      state: "open",
+      assignees: [],
+      milestone: null,
+      comments: [],
+    });
+  }
+  listLabels(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+}
+
+// =============================================================================
+// Config builders
+// =============================================================================
+
+/**
+ * Minimal valid workflow config. Adding a `labels` block is opt-in per
+ * test so the "no labels section → preflight is a no-op" case is
+ * covered without fighting the test builder.
+ */
+function baseConfig(
+  labels?: Record<string, { color: string; description: string }>,
+): WorkflowConfig {
+  return {
+    version: "1.0.0",
+    phases: {
+      implementation: { type: "actionable", priority: 1, agent: "iterator" },
+      complete: { type: "terminal" },
+    },
+    labelMapping: {
+      ready: "implementation",
+      done: "complete",
+    },
+    agents: {
+      iterator: {
+        role: "transformer",
+        outputPhase: "complete",
+        fallbackPhase: "complete",
+      },
+    },
+    rules: {
+      maxCycles: 1,
+      cycleDelayMs: 0,
+      maxConsecutivePhases: 0,
+    },
+    labels,
+  };
+}
+
+// =============================================================================
+// BatchRunner preflight wiring
+// =============================================================================
+
+Deno.test("BatchRunner: preflight creates missing labels declared in workflow.json", async () => {
+  const github = new RecordingGithubClient(/* empty baseline */);
+  const config = baseConfig({
+    "kind:impl": { color: "a2eeef", description: "impl work" },
+    "done": { color: "0e8a16", description: "terminal" },
+  });
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const orchestrator = new Orchestrator(
+      config,
+      github,
+      new StubDispatcher(),
+      tmpDir,
+    );
+    const runner = new BatchRunner(
+      orchestrator,
+      config,
+      github,
+      new StubDispatcher(),
+      tmpDir,
+    );
+    await runner.run({});
+
+    // Exactly one baseline read (one preflight invocation per batch).
+    const lists = github.labelCalls.filter((c) => c.op === "list");
+    assertEquals(
+      lists.length,
+      1,
+      "BatchRunner must invoke listLabelsDetailed exactly once (preflight runs once per batch).",
+    );
+
+    // Both declared specs must have been created, in declaration order.
+    const creates = github.labelCalls.filter((c) => c.op === "create");
+    assertEquals(
+      creates.map((c) => c.name),
+      ["kind:impl", "done"],
+      "All labels declared in workflow.json#labels must be created during preflight.",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("BatchRunner: preflight updates labels whose color drifted", async () => {
+  const github = new RecordingGithubClient([
+    // Existing label with stale color.
+    { name: "kind:impl", color: "ffffff", description: "impl work" },
+  ]);
+  const config = baseConfig({
+    "kind:impl": { color: "a2eeef", description: "impl work" },
+  });
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const orchestrator = new Orchestrator(
+      config,
+      github,
+      new StubDispatcher(),
+      tmpDir,
+    );
+    const runner = new BatchRunner(
+      orchestrator,
+      config,
+      github,
+      new StubDispatcher(),
+      tmpDir,
+    );
+    await runner.run({});
+
+    const updates = github.labelCalls.filter((c) => c.op === "update");
+    assertEquals(updates.length, 1);
+    assertEquals(updates[0].name, "kind:impl");
+    assertEquals(updates[0].color, "a2eeef");
+
+    // No creates (label already existed).
+    assertEquals(
+      github.labelCalls.filter((c) => c.op === "create").length,
+      0,
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("BatchRunner: preflight is a no-op when workflow.json has no labels section", async () => {
+  const github = new RecordingGithubClient();
+  const config = baseConfig(/* no labels */);
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const orchestrator = new Orchestrator(
+      config,
+      github,
+      new StubDispatcher(),
+      tmpDir,
+    );
+    const runner = new BatchRunner(
+      orchestrator,
+      config,
+      github,
+      new StubDispatcher(),
+      tmpDir,
+    );
+    await runner.run({});
+
+    // No label-spec API call of any kind: preflight short-circuits when
+    // `labels` is absent so pre-Phase-2 configs continue to work.
+    assertEquals(
+      github.labelCalls.length,
+      0,
+      "Preflight must not invoke any label API when workflow.json has no labels section.",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("BatchRunner: preflight dryRun skips create/update but still lists", async () => {
+  const github = new RecordingGithubClient(/* empty baseline */);
+  const config = baseConfig({
+    "kind:impl": { color: "a2eeef", description: "impl" },
+  });
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const orchestrator = new Orchestrator(
+      config,
+      github,
+      new StubDispatcher(),
+      tmpDir,
+    );
+    const runner = new BatchRunner(
+      orchestrator,
+      config,
+      github,
+      new StubDispatcher(),
+      tmpDir,
+    );
+    await runner.run({}, { dryRun: true });
+
+    // dryRun still reads baseline (that's harmless and informs the summary).
+    assertEquals(
+      github.labelCalls.filter((c) => c.op === "list").length,
+      1,
+    );
+    // But must NOT mutate — this is the core dryRun contract.
+    assertEquals(
+      github.labelCalls.filter(
+        (c) => c.op === "create" || c.op === "update",
+      ).length,
+      0,
+      "dryRun preflight must never invoke createLabel or updateLabel.",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+// =============================================================================
+// Orchestrator (single-issue mode) preflight wiring
+// =============================================================================
+
+Deno.test("Orchestrator.run: single-issue mode invokes preflight when logger is owned", async () => {
+  const github = new RecordingGithubClient();
+  const config = baseConfig({
+    "kind:impl": { color: "a2eeef", description: "impl" },
+  });
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const orchestrator = new Orchestrator(
+      config,
+      github,
+      new StubDispatcher({ iterator: "success" }),
+      tmpDir,
+    );
+    // No `logger` arg → ownsLogger === true → preflight must fire.
+    // Issue lookup short-circuits because getIssueLabels returns [].
+    await orchestrator.run(1);
+
+    assertEquals(
+      github.labelCalls.filter((c) => c.op === "list").length,
+      1,
+      "Single-issue mode must run preflight exactly once when no external logger is passed.",
+    );
+    assertEquals(
+      github.labelCalls.filter((c) => c.op === "create").length,
+      1,
+      "Preflight should have created the one declared label.",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("Orchestrator.runBatch: preflight runs exactly once across batch + per-issue", async () => {
+  // This is the double-sync guard: BatchRunner passes its own logger
+  // into Orchestrator.run per issue, so Orchestrator's ownsLogger check
+  // must skip the inner preflight. Net effect: one preflight per batch,
+  // regardless of how many issues are in the batch.
+  const github = new RecordingGithubClient();
+  const config = baseConfig({
+    "kind:impl": { color: "a2eeef", description: "impl" },
+  });
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const orchestrator = new Orchestrator(
+      config,
+      github,
+      new StubDispatcher({ iterator: "success" }),
+      tmpDir,
+    );
+    await orchestrator.runBatch({});
+
+    // listLabelsDetailed must be called exactly once (batch preflight);
+    // if Orchestrator double-syncs the count would be >1.
+    assertEquals(
+      github.labelCalls.filter((c) => c.op === "list").length,
+      1,
+      "Preflight must not double-run: BatchRunner handles the sync, Orchestrator.run must skip it when a batch logger was injected.",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/agents/orchestrator/workflow-loader.ts
+++ b/agents/orchestrator/workflow-loader.ts
@@ -15,6 +15,9 @@ import {
 } from "./workflow-types.ts";
 import {
   wfLabelMappingEmpty,
+  wfLabelSpecInvalidColor,
+  wfLabelSpecMissing,
+  wfLabelSpecOrphan,
   wfLabelUnknownPhase,
   wfLoadInvalidJson,
   wfLoadNotFound,
@@ -86,6 +89,7 @@ export async function loadWorkflow(
     labelPrefix: parsed.labelPrefix as string | undefined,
     phases: parsed.phases as WorkflowConfig["phases"],
     labelMapping: parsed.labelMapping as WorkflowConfig["labelMapping"],
+    labels: parsed.labels as WorkflowConfig["labels"],
     agents: parsed.agents as WorkflowConfig["agents"],
     rules: applyDefaultRules(
       parsed.rules as Partial<WorkflowRules> | undefined,
@@ -189,6 +193,55 @@ function validateCrossReferences(config: WorkflowConfig): void {
   // 4 & 5. Agent outputPhase/outputPhases/fallbackPhase must exist in phases
   for (const [agentId, agent] of Object.entries(config.agents)) {
     validateAgentPhaseReferences(agentId, agent, phaseIds);
+  }
+
+  // 6. labels[] completeness + color format
+  validateLabelsSection(config);
+}
+
+const HEX_COLOR_RE = /^[0-9a-fA-F]{6}$/;
+
+/**
+ * Validate the `labels` section when declared.
+ *
+ * Opt-in semantics: if `labels` is absent from workflow.json, no
+ * validation runs (backwards compat for pre-Phase-2 configs that
+ * relied on an external bootstrap). Once `labels` is declared —
+ * even as `{}` — the full completeness / orphan / color-format
+ * contract is enforced. This forces any config that adopts the
+ * declarative model to do so consistently.
+ */
+function validateLabelsSection(config: WorkflowConfig): void {
+  if (config.labels === undefined) return;
+
+  // Required labels = labelMapping keys ∪ prioritizer.labels
+  const requiredLabels = new Set<string>(Object.keys(config.labelMapping));
+  if (config.prioritizer) {
+    for (const label of config.prioritizer.labels) {
+      requiredLabels.add(label);
+    }
+  }
+
+  const declaredLabels = config.labels;
+  const declaredKeys = new Set(Object.keys(declaredLabels));
+
+  // Completeness: every required label must appear in labels[]
+  const missing = [...requiredLabels].filter((l) => !declaredKeys.has(l));
+  if (missing.length > 0) {
+    throw wfLabelSpecMissing(missing.sort());
+  }
+
+  // Orphans: declared specs must be referenced somewhere
+  const orphans = [...declaredKeys].filter((l) => !requiredLabels.has(l));
+  if (orphans.length > 0) {
+    throw wfLabelSpecOrphan(orphans.sort());
+  }
+
+  // Color format: 6-char hex, no leading '#'
+  for (const [name, spec] of Object.entries(declaredLabels)) {
+    if (!HEX_COLOR_RE.test(spec.color)) {
+      throw wfLabelSpecInvalidColor(name, spec.color);
+    }
   }
 }
 

--- a/agents/orchestrator/workflow-loader_test.ts
+++ b/agents/orchestrator/workflow-loader_test.ts
@@ -620,3 +620,177 @@ Deno.test(
     }
   },
 );
+
+// =============================================================================
+// labels section — opt-in validation (WF-LABEL-003 / 004 / 005)
+//
+// When `labels` is absent, validation is skipped (backwards compat with
+// pre-Phase-2 configs). When declared — even as {} — the full
+// completeness + orphan + color-format contract is enforced.
+// =============================================================================
+
+/** Extend validConfig() with a `labels` section. */
+function configWithLabels(
+  labels: Record<string, { color: string; description: string }>,
+): Record<string, unknown> {
+  const cfg = validConfig();
+  cfg.labels = labels;
+  return cfg;
+}
+
+Deno.test("workflow-loader: labels absent → validation skipped (backwards compat)", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // validConfig() has no `labels` field; should load cleanly.
+    await writeFixture(dir, validConfig());
+    const config = await loadWorkflow(dir);
+    assertEquals(
+      config.labels,
+      undefined,
+      "labels must remain undefined when omitted — no implicit default.",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: WF-LABEL-003 — labels present but missing spec for a labelMapping key", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // labelMapping has 4 keys (ready, review, done, blocked); declare only 3.
+    const cfg = configWithLabels({
+      ready: { color: "a2eeef", description: "ready for work" },
+      review: { color: "fbca04", description: "under review" },
+      done: { color: "0e8a16", description: "complete" },
+      // "blocked" intentionally missing.
+    });
+    await writeFixture(dir, cfg);
+    const err = await assertRejects(() => loadWorkflow(dir), Error);
+    assertStringIncludes(err.message, "WF-LABEL-003");
+    assertStringIncludes(
+      err.message,
+      "blocked",
+      "Error must name the specific missing label to guide the fix.",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: WF-LABEL-003 — prioritizer.labels entry without a spec fails", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const cfg = configWithLabels({
+      ready: { color: "a2eeef", description: "ready for work" },
+      review: { color: "fbca04", description: "under review" },
+      done: { color: "0e8a16", description: "complete" },
+      blocked: { color: "d93f0b", description: "blocked" },
+      // "order:1" referenced by prioritizer below — not declared.
+    });
+    cfg.prioritizer = {
+      mode: "label-based",
+      labels: ["order:1"],
+    };
+    await writeFixture(dir, cfg);
+    const err = await assertRejects(() => loadWorkflow(dir), Error);
+    assertStringIncludes(err.message, "WF-LABEL-003");
+    assertStringIncludes(err.message, "order:1");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: WF-LABEL-004 — orphan spec not referenced anywhere fails", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const cfg = configWithLabels({
+      ready: { color: "a2eeef", description: "ready for work" },
+      review: { color: "fbca04", description: "under review" },
+      done: { color: "0e8a16", description: "complete" },
+      blocked: { color: "d93f0b", description: "blocked" },
+      // Orphan: referenced by neither labelMapping nor prioritizer.labels.
+      "legacy:abandoned": { color: "cccccc", description: "orphan" },
+    });
+    await writeFixture(dir, cfg);
+    const err = await assertRejects(() => loadWorkflow(dir), Error);
+    assertStringIncludes(err.message, "WF-LABEL-004");
+    assertStringIncludes(err.message, "legacy:abandoned");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: WF-LABEL-005 — invalid color (non-hex) fails", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const cfg = configWithLabels({
+      ready: { color: "not-a-hex", description: "ready for work" },
+      review: { color: "fbca04", description: "under review" },
+      done: { color: "0e8a16", description: "complete" },
+      blocked: { color: "d93f0b", description: "blocked" },
+    });
+    await writeFixture(dir, cfg);
+    const err = await assertRejects(() => loadWorkflow(dir), Error);
+    assertStringIncludes(err.message, "WF-LABEL-005");
+    assertStringIncludes(err.message, "ready");
+    assertStringIncludes(err.message, "not-a-hex");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: WF-LABEL-005 — leading '#' on color rejected", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // Common paste mistake — GitHub's label API rejects leading '#'.
+    const cfg = configWithLabels({
+      ready: { color: "#a2eeef", description: "ready" },
+      review: { color: "fbca04", description: "review" },
+      done: { color: "0e8a16", description: "done" },
+      blocked: { color: "d93f0b", description: "blocked" },
+    });
+    await writeFixture(dir, cfg);
+    const err = await assertRejects(() => loadWorkflow(dir), Error);
+    assertStringIncludes(err.message, "WF-LABEL-005");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: valid labels section (complete + in-spec) loads", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const cfg = configWithLabels({
+      ready: { color: "a2eeef", description: "ready for work" },
+      review: { color: "fbca04", description: "under review" },
+      done: { color: "0e8a16", description: "complete" },
+      blocked: { color: "d93f0b", description: "blocked" },
+    });
+    await writeFixture(dir, cfg);
+    const config = await loadWorkflow(dir);
+    assertEquals(Object.keys(config.labels ?? {}).length, 4);
+    assertEquals(config.labels?.ready?.color, "a2eeef");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("workflow-loader: uppercase hex colors accepted", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // GitHub normalises to lowercase internally, but the loader must
+    // accept either form to avoid gratuitously rejecting human-authored
+    // configs that use the Cb palette docs (often uppercase).
+    const cfg = configWithLabels({
+      ready: { color: "A2EEEF", description: "ready" },
+      review: { color: "FBCA04", description: "review" },
+      done: { color: "0E8A16", description: "done" },
+      blocked: { color: "D93F0B", description: "blocked" },
+    });
+    await writeFixture(dir, cfg);
+    const config = await loadWorkflow(dir);
+    assertEquals(config.labels?.ready?.color, "A2EEEF");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/agents/orchestrator/workflow-schema.json
+++ b/agents/orchestrator/workflow-schema.json
@@ -46,6 +46,27 @@
         "type": "string"
       }
     },
+    "labels": {
+      "type": "object",
+      "description": "Declarative GitHub label specs keyed by label name. Every label referenced in labelMapping and prioritizer.labels must appear here. Color is a 6-char hex (no '#'). Orchestrator/triager sync these to the repository at startup.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["color", "description"],
+        "additionalProperties": false,
+        "properties": {
+          "color": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{6}$",
+            "description": "GitHub label color as 6-char hex (no leading '#')."
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable label description surfaced in GitHub UI."
+          }
+        }
+      }
+    },
     "agents": {
       "type": "object",
       "description": "Agent definitions keyed by agent ID",

--- a/agents/orchestrator/workflow-types.ts
+++ b/agents/orchestrator/workflow-types.ts
@@ -81,6 +81,24 @@ export interface ValidatorDefinition extends BaseAgentDefinition {
 /** Discriminated union of all agent definition types */
 export type AgentDefinition = TransformerDefinition | ValidatorDefinition;
 
+// === Labels ===
+
+/**
+ * Declarative GitHub label specification.
+ *
+ * Drives idempotent pre-dispatch sync so orchestrator and triager never
+ * depend on a bash bootstrap block living inside a prompt file. Every
+ * label referenced by `labelMapping` or `prioritizer.labels` must have
+ * a matching entry here — enforced by the loader.
+ */
+export interface LabelSpec {
+  /** 6-char hex GitHub label color (no leading `#`) */
+  color: string;
+
+  /** Human-readable description surfaced in the GitHub UI */
+  description: string;
+}
+
 // === Handoff ===
 
 /** Configuration for inter-agent handoff communication */
@@ -166,6 +184,17 @@ export interface WorkflowConfig {
 
   /** GitHub label to phase ID mapping */
   labelMapping: Record<string, string>;
+
+  /**
+   * Declarative GitHub label specifications keyed by label name.
+   *
+   * Owns color + description for every label the workflow touches.
+   * Orchestrator/triager sync this to the repository at startup
+   * (idempotent, per-label try/catch). Cross-referenced against
+   * `labelMapping` keys and `prioritizer.labels` by the loader —
+   * missing entries are a configuration error (WF-LABEL-003).
+   */
+  labels?: Record<string, LabelSpec>;
 
   /** Agent definitions keyed by agent ID */
   agents: Record<string, AgentDefinition>;

--- a/agents/scripts/sync-labels.ts
+++ b/agents/scripts/sync-labels.ts
@@ -1,0 +1,118 @@
+/**
+ * Label Sync CLI
+ *
+ * Standalone entry point that reconciles GitHub labels declared in
+ * workflow.json#labels against the repository. Used as a pre-dispatch
+ * hook for agents (notably the triager) that need the workflow label
+ * set present before they run.
+ *
+ * The triager prompt invokes this CLI as Step 1 in place of the old
+ * bash bootstrap block. Orchestrator batch mode already performs the
+ * same reconciliation inside BatchRunner#preflightLabelSync, so this
+ * script is only needed when running a label-consuming agent outside
+ * the orchestrator.
+ *
+ * @module
+ *
+ * @example Sync labels using the default workflow.json
+ * ```bash
+ * deno task labels:sync
+ * ```
+ *
+ * @example Dry-run against a custom workflow file
+ * ```bash
+ * deno task labels:sync --workflow my-workflow.json --dry-run
+ * ```
+ */
+
+import { parseArgs } from "@std/cli/parse-args";
+import { loadWorkflow } from "../orchestrator/workflow-loader.ts";
+import { GhCliClient } from "../orchestrator/github-client.ts";
+import {
+  summarizeSync,
+  syncLabels,
+  type SyncResult,
+} from "../orchestrator/label-sync.ts";
+
+function printHelp(): void {
+  // deno-lint-ignore no-console
+  console.log(`
+Label Sync CLI
+
+Usage:
+  deno run --allow-all agents/scripts/sync-labels.ts [options]
+  deno task labels:sync [options]
+
+Options:
+  --workflow <path>  Path to workflow JSON (default: .agent/workflow.json)
+  --dry-run          Compute actions without touching the repository
+  --help, -h         Show this help message
+
+Exit codes:
+  0  All specs synced successfully (or nothing to do)
+  1  One or more per-label operations failed
+  2  CLI / config error (workflow load, unreadable repo state, etc.)
+`);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(Deno.args, {
+    string: ["workflow"],
+    boolean: ["help", "dry-run"],
+    alias: { h: "help", w: "workflow" },
+  });
+
+  if (args.help) {
+    printHelp();
+    Deno.exit(0);
+  }
+
+  const cwd = Deno.cwd();
+  let config;
+  try {
+    config = await loadWorkflow(cwd, args.workflow);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    // deno-lint-ignore no-console
+    console.error(`Failed to load workflow: ${msg}`);
+    Deno.exit(2);
+  }
+
+  const specs = config.labels;
+  if (!specs || Object.keys(specs).length === 0) {
+    // deno-lint-ignore no-console
+    console.log("No labels[] declared in workflow.json — nothing to sync.");
+    Deno.exit(0);
+  }
+
+  const github = new GhCliClient(cwd);
+
+  let results: SyncResult[];
+  try {
+    results = await syncLabels(github, specs, { dryRun: args["dry-run"] });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    // deno-lint-ignore no-console
+    console.error(`Failed to read repository label state: ${msg}`);
+    Deno.exit(2);
+  }
+
+  // deno-lint-ignore no-console
+  console.log(summarizeSync(results));
+  for (const r of results) {
+    if (r.action === "failed") {
+      // deno-lint-ignore no-console
+      console.error(`  ${r.name}: FAILED — ${r.error ?? "unknown error"}`);
+    } else if (r.action !== "nochange") {
+      // deno-lint-ignore no-console
+      console.log(`  ${r.name}: ${r.action}`);
+    }
+  }
+
+  const hasFailure = results.some((r) => r.action === "failed");
+  Deno.exit(hasFailure ? 1 : 0);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/agents/shared/errors/config-errors.ts
+++ b/agents/shared/errors/config-errors.ts
@@ -512,6 +512,45 @@ export function wfLabelUnknownPhase(
   );
 }
 
+export function wfLabelSpecMissing(
+  missingLabels: readonly string[],
+): ConfigError {
+  const list = missingLabels.map((l) => `"${l}"`).join(", ");
+  return new ConfigError(
+    "WF-LABEL-003",
+    `Workflow config: labels[] is missing specs for: [${list}].`,
+    `Every label referenced by labelMapping or prioritizer.labels must have a matching entry in "labels" so the pre-dispatch sync can create/update it with the correct color and description. Missing specs would force the sync to invent defaults, drifting from the declared source of truth.`,
+    `Add entries to "labels" in workflow.json for: [${list}], each with { "color": "<6-hex>", "description": "<text>" }.`,
+    "workflow.json",
+  );
+}
+
+export function wfLabelSpecOrphan(
+  orphanLabels: readonly string[],
+): ConfigError {
+  const list = orphanLabels.map((l) => `"${l}"`).join(", ");
+  return new ConfigError(
+    "WF-LABEL-004",
+    `Workflow config: labels[] declares specs not referenced by labelMapping or prioritizer.labels: [${list}].`,
+    `Orphan label specs risk drifting from runtime behavior — if a label is declared but never used, the sync still pushes it and a later contributor has no signal about whether removing it is safe. Keep the label set tight.`,
+    `Either reference the label from labelMapping / prioritizer.labels, or remove the entry from "labels" in workflow.json.`,
+    "workflow.json",
+  );
+}
+
+export function wfLabelSpecInvalidColor(
+  label: string,
+  color: string,
+): ConfigError {
+  return new ConfigError(
+    "WF-LABEL-005",
+    `Workflow config: labels["${label}"].color "${color}" is not a valid 6-char hex value.`,
+    `GitHub label colors must be exactly 6 hex characters without a leading "#". Any other form will cause the label sync API call to fail.`,
+    `Change labels["${label}"].color in workflow.json to a 6-character hex value (0-9, a-f), e.g. "a2eeef".`,
+    "workflow.json",
+  );
+}
+
 // --- WF-RULE: Rules validation ---
 
 export function wfRuleMaxCyclesInvalid(value: number): ConfigError {

--- a/deno.json
+++ b/deno.json
@@ -75,6 +75,7 @@
     "generate-registry": "deno run --allow-read --allow-write --allow-env scripts/generate-registry.ts",
     "orchestrator": "deno run --allow-all agents/scripts/run-workflow.ts",
     "agent": "deno run --allow-all agents/scripts/run-agent.ts",
+    "labels:sync": "deno run --allow-all agents/scripts/sync-labels.ts",
     "iterate-agent": "deno run --allow-all agents/scripts/run-agent.ts --agent iterator",
     "review-agent": "deno run --allow-all agents/scripts/run-agent.ts --agent reviewer",
     "facilitate-agent": "deno run --allow-all agents/scripts/run-agent.ts --agent facilitator",


### PR DESCRIPTION
## Summary

- Move label metadata (name/color/description) from bash case-statement embedded in triager prompt to declarative \`labels:\` section in \`workflow.json\`
- Add \`syncLabels\` with per-label try/catch (no \`set -e\` early abort — root cause of the \`need clearance\` bootstrap gap)
- Wire preflight sync at orchestrator batch start and via \`deno task labels:sync\` (triager Step 1)
- Fix kind:detail drift: now declared alongside other kind:* labels

## Design

Per tmp/label-bootstrap-failure/investigation/T6-design-judgment.md (Q2.b): workflow.json already owns \`labelMapping\`, \`phases\`, \`agents\`, \`prioritizer.labels\` — label specs belong there too. Removes data-dressed-as-prompt pattern from triager.

## Changes

- \`workflow-types.ts\` / \`workflow-schema.json\`: \`LabelSpec\` + \`WorkflowConfig.labels?\` (opt-in; enforced once declared)
- \`workflow-loader.ts\`: \`validateLabelsSection\` — completeness / orphan / hex-format (WF-LABEL-003/004/005)
- \`label-sync.ts\` (new): idempotent per-label try/catch with dryRun and order-preserving results
- \`github-client.ts\` / \`file-github-client.ts\`: \`listLabelsDetailed\` / \`createLabel\` / \`updateLabel\`
- \`batch-runner.ts\` / \`orchestrator.ts\`: preflight sync (batch start + single-issue gate)
- \`scripts/sync-labels.ts\` (new): standalone CLI
- \`.agent/workflow.json\`: \`labels\` section with 14 specs incl. \`kind:detail\`
- \`.agent/triager/prompts/.../f_default.md\`: bash block → \`deno task labels:sync\`
- \`.agent/CLAUDE.md\`: workflow.json documented as single source of truth

## Test plan

- [x] \`deno test --allow-all agents/orchestrator/\` — 368/368 pass
- [x] \`deno test --allow-all agents/\` — 1546/1546 pass
- [x] New tests: label-sync unit (15), workflow-loader (8), preflight-wiring (6)
- [x] \`deno task labels:sync --help\` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)