### PR TITLE
ci: trigger test workflow on PRs to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
     paths-ignore:
       - 'CHANGELOG.md'
       - 'docs/**'


### PR DESCRIPTION
## Summary

Branch protection on `main` requires the `test` status check, but `test.yml` only triggered on PRs to `develop`. This made `develop → main` merges impossible without admin bypass.

Fix: add `main` to the `pull_request.branches` list so the test workflow runs on PRs targeting either branch.

## Test plan

- [x] Unblocks PR #481 (develop → main for release 1.13.26)
- [x] Workflow syntax unchanged aside from branch list

🤖 Generated with [Claude Code](https://claude.com/claude-code)