### PR TITLE
Release 1.13.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.27] - 2026-04-20
+
+### Fixed
+- Bump `@tettuan/breakdownconfig` `^1.2.4` → `^1.2.6`, which removes
+  the absolute-path allowlist that rejected realpath-resolved
+  `/private/tmp/...` baseDirs on macOS and user-home `baseDir`
+  entries; traversal (`..`) remains rejected (#517)
+- Bump `BREAKDOWN_VERSION` 1.8.7 → 1.8.9 to pick up the refreshed
+  `breakdownconfig` transitive packaging
+
 ## [1.13.26] - 2026-04-18
 
 ### Added

--- a/deno.json
+++ b/deno.json
@@ -98,7 +98,7 @@
     "@std/flags": "jsr:@std/flags@^0.224.0",
     "@std/fs": "jsr:@std/fs@^1.0.22",
     "@std/path": "jsr:@std/path@^1.1.4",
-    "@tettuan/breakdownconfig": "jsr:@tettuan/breakdownconfig@^1.2.4",
+    "@tettuan/breakdownconfig": "jsr:@tettuan/breakdownconfig@^1.2.6",
     "@tettuan/breakdownlogger": "jsr:@tettuan/breakdownlogger@^1.1.3",
     "zod": "npm:zod@^4.0.0"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.13.26",
+  "version": "1.13.27",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.13.26",
+  "version": "1.13.27",
   "entries": [
     {
       "id": "builder-01_quickstart",

--- a/src/version.ts
+++ b/src/version.ts
@@ -44,7 +44,7 @@ export const CLIMPT_VERSION = "1.13.27";
  * const mod = await import(`jsr:@tettuan/breakdown@${BREAKDOWN_VERSION}`);
  * ```
  */
-export const BREAKDOWN_VERSION = "1.8.7";
+export const BREAKDOWN_VERSION = "1.8.9";
 
 /**
  * Version of the frontmatter-to-schema package to use.

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.13.26";
+export const CLIMPT_VERSION = "1.13.27";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Summary
Release 1.13.27 — fix breakdownconfig absolute-path baseDir (#517).

### Changes
- Bump @tettuan/breakdownconfig ^1.2.4 → ^1.2.6 (removes the absolute-path allowlist that rejected /Users/... and realpath-resolved /private/tmp/... baseDirs).
- Bump BREAKDOWN_VERSION 1.8.7 → 1.8.9 (transitive breakdownconfig packaging refresh).
- Docs: CHANGELOG + manifest updated.
- No CLI-visible or public API changes.

### Verification
- deno task ci: 1715 tests, 7/7 stages pass
- ./examples/run-all.sh: 54/54 passed
- Remote CI (dispatch): https://github.com/tettuan/climpt/actions/runs/24672525752
- PR to develop: #518 (merged at 62c9072)

Closes #517.