### PR TITLE
chore: merge release/1.13.28 into release/1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.27] - 2026-04-20
+
+### Fixed
+- Bump `@tettuan/breakdownconfig` `^1.2.4` → `^1.2.6`, which removes
+  the absolute-path allowlist that rejected realpath-resolved
+  `/private/tmp/...` baseDirs on macOS and user-home `baseDir`
+  entries; traversal (`..`) remains rejected (#517)
+- Bump `BREAKDOWN_VERSION` 1.8.7 → 1.8.9 to pick up the refreshed
+  `breakdownconfig` transitive packaging
+
 ## [1.13.26] - 2026-04-18
 
 ### Added

--- a/deno.json
+++ b/deno.json
@@ -98,7 +98,7 @@
     "@std/flags": "jsr:@std/flags@^0.224.0",
     "@std/fs": "jsr:@std/fs@^1.0.22",
     "@std/path": "jsr:@std/path@^1.1.4",
-    "@tettuan/breakdownconfig": "jsr:@tettuan/breakdownconfig@^1.2.4",
+    "@tettuan/breakdownconfig": "jsr:@tettuan/breakdownconfig@^1.2.6",
     "@tettuan/breakdownlogger": "jsr:@tettuan/breakdownlogger@^1.1.3",
     "zod": "npm:zod@^4.0.0"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.13.26",
+  "version": "1.13.27",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aidevtool/climpt",
-  "version": "1.13.27",
+  "version": "1.13.28",
   "description": "A CLI wrapper around @tettuan/breakdown for AI-assisted development instruction tools. Provides unified interface for creating, managing, and executing development instructions using TypeScript and JSON Schema for AI system interpretation.",
   "license": "MIT",
   "author": "tettuan",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.13.26",
+  "version": "1.13.27",
   "entries": [
     {
       "id": "builder-01_quickstart",

--- a/src/version.ts
+++ b/src/version.ts
@@ -44,7 +44,7 @@ export const CLIMPT_VERSION = "1.13.27";
  * const mod = await import(`jsr:@tettuan/breakdown@${BREAKDOWN_VERSION}`);
  * ```
  */
-export const BREAKDOWN_VERSION = "1.8.7";
+export const BREAKDOWN_VERSION = "1.8.9";
 
 /**
  * Version of the frontmatter-to-schema package to use.

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.13.27";
+export const CLIMPT_VERSION = "1.13.28";
 
 /**
  * Version of the breakdown package to use.

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * console.log(`Climpt version: ${CLIMPT_VERSION}`);
  * ```
  */
-export const CLIMPT_VERSION = "1.13.26";
+export const CLIMPT_VERSION = "1.13.27";
 
 /**
  * Version of the breakdown package to use.


### PR DESCRIPTION
## Purpose

Forward-port the dependency bumps shipped in `release/1.13.28` to the current `release/1.14.0` line so the 1.14.0 release picks up the `breakdownconfig` baseDir fix without losing the 1.14.0 schema migration work.

## Commits picked up from release/1.13.28

- `47591d2` chore: bump version to 1.13.28
- `4af87ad` Merge pull request #519 from tettuan/develop
- `62c9072` Merge pull request #518 from tettuan/release/1.13.27
- `8aa7625` docs: update changelog and manifest for 1.13.27
- `dbe6893` fix(deps): bump breakdownconfig ^1.2.6 and breakdown 1.8.9 (#517)
- `c99c421` chore: bump version to 1.13.27

## Conflict resolution

Three text conflicts (all mechanical) plus one auto-merged adjustment:

| File | Decision |
|---|---|
| `deno.json` `version` | keep `1.14.0` (current release line) |
| `deno.json` `@tettuan/breakdownconfig` | already `^1.2.6` on both sides, no change |
| `src/version.ts` `CLIMPT_VERSION` | keep `1.14.0` |
| `src/version.ts` `BREAKDOWN_VERSION` | adopt `1.8.9` from 1.13.28 |
| `CHANGELOG.md` | keep both sections in chrono order: 1.14.0 entry first, 1.13.27 entry directly below |
| `docs/manifest.json` `version` | aligned to `1.14.0` to match `deno.json` (auto-merge took 1.13.27; corrected for consistency) |

`git diff --check` shows no residual conflict markers; `deno check src/version.ts` passes.

## Out of scope

- No source-code or workflow.json changes; this is purely a forward-port of the `release/1.13.28` lineage.